### PR TITLE
fix(hr): surface leave submission errors and add draft retry action

### DIFF
--- a/packages/client/src/apps/hr/components/views/my-leave-view.tsx
+++ b/packages/client/src/apps/hr/components/views/my-leave-view.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Plus, Check, XCircle, X } from 'lucide-react';
+import { Plus, Check, XCircle, X, Send } from 'lucide-react';
 import {
   useLeaveTypes, useLeaveApplications, useCreateLeaveApplication,
   useSubmitLeaveApplication, useApproveLeaveApplication,
@@ -20,6 +20,7 @@ import { FeatureEmptyState } from '../../../../components/ui/feature-empty-state
 import { formatDate } from '../../../../lib/format';
 import { useMyAppPermission } from '../../../../hooks/use-app-permissions';
 import { useAuthStore } from '../../../../stores/auth-store';
+import { useToastStore } from '../../../../stores/toast-store';
 
 export function MyLeaveView({ employees }: { employees: HrEmployee[] }) {
   const { t } = useTranslation();
@@ -34,6 +35,7 @@ export function MyLeaveView({ employees }: { employees: HrEmployee[] }) {
   // Permission + self-identification used to gate the approve/reject
   // icon buttons. Viewers can never approve; even privileged roles
   // should never approve their own records.
+  const addToast = useToastStore((s) => s.addToast);
   const { data: hrPerm } = useMyAppPermission('hr');
   const canApprove = hrPerm?.role === 'admin' || hrPerm?.role === 'editor';
   const authAccount = useAuthStore((s) => s.account);
@@ -69,8 +71,12 @@ export function MyLeaveView({ employees }: { employees: HrEmployee[] }) {
       onSuccess: (data) => {
         setShowRequest(false);
         setReqEmployeeId(''); setReqLeaveTypeId(''); setReqStartDate(''); setReqEndDate(''); setReqReason(''); setReqHalfDay(false);
-        // Auto-submit
-        if (data?.id) submitApp.mutate(data.id);
+        if (data?.id) submitApp.mutate(data.id, {
+          onError: (err: unknown) => {
+            const msg = err instanceof Error ? err.message : t('hr.myLeave.submitFailed');
+            addToast({ type: 'error', message: msg });
+          },
+        });
       },
     });
   };
@@ -130,6 +136,14 @@ export function MyLeaveView({ employees }: { employees: HrEmployee[] }) {
                   <IconButton icon={<Check size={14} />} label={t('hr.actions.approve')} size={26} onClick={() => approveApp.mutate({ id: app.id })} style={{ color: 'var(--color-success)' }} />
                   <IconButton icon={<XCircle size={14} />} label={t('hr.actions.reject')} size={26} destructive onClick={() => rejectApp.mutate({ id: app.id })} />
                 </>
+              )}
+              {app.status === 'draft' && app.employeeId === myEmployee?.id && (
+                <IconButton icon={<Send size={14} />} label={t('hr.myLeave.retrySubmit')} size={26} onClick={() => submitApp.mutate(app.id, {
+                  onError: (err: unknown) => {
+                    const msg = err instanceof Error ? err.message : t('hr.myLeave.submitFailed');
+                    addToast({ type: 'error', message: msg });
+                  },
+                })} />
               )}
               {app.status === 'approved' && app.employeeId === myEmployee?.id && (
                 <IconButton icon={<X size={14} />} label={t('hr.myLeave.cancel')} size={26} destructive onClick={() => cancelApp.mutate(app.id)} />

--- a/packages/client/src/i18n/locales/de.json
+++ b/packages/client/src/i18n/locales/de.json
@@ -2694,7 +2694,9 @@
       "submit": "Antrag einreichen",
       "cancel": "Urlaub stornieren",
       "emptyDesc": "Reichen Sie einen Urlaubsantrag ein, um zu beginnen. Ihr Vorgesetzter wird zur Genehmigung benachrichtigt.",
-      "request": "Urlaub beantragen"
+      "request": "Urlaub beantragen",
+      "submitFailed": "Urlaubsantrag konnte nicht eingereicht werden. Bitte überprüfen Sie Ihr Urlaubsguthaben und Ihre Richtlinie.",
+      "retrySubmit": "Antrag einreichen"
     },
     "teamCalendar": {
       "noLeaves": "Keine genehmigten Abwesenheiten fuer diesen Monat."

--- a/packages/client/src/i18n/locales/en.json
+++ b/packages/client/src/i18n/locales/en.json
@@ -2724,7 +2724,9 @@
       "selectType": "Select leave type...",
       "reason": "Reason",
       "submit": "Submit request",
-      "cancel": "Cancel leave"
+      "cancel": "Cancel leave",
+      "submitFailed": "Failed to submit leave request. Please check your leave balance and policy.",
+      "retrySubmit": "Submit request"
     },
     "teamCalendar": {
       "noLeaves": "No approved leaves for this month."

--- a/packages/client/src/i18n/locales/fr.json
+++ b/packages/client/src/i18n/locales/fr.json
@@ -2694,7 +2694,9 @@
       "submit": "Soumettre",
       "cancel": "Annuler le conge",
       "emptyDesc": "Soumettez une demande de congé pour commencer. Votre responsable sera notifié pour approbation.",
-      "request": "Demander un congé"
+      "request": "Demander un congé",
+      "submitFailed": "Échec de l'envoi de la demande de congé. Veuillez vérifier votre solde de congés et votre politique.",
+      "retrySubmit": "Soumettre la demande"
     },
     "teamCalendar": {
       "noLeaves": "Aucun conge approuve pour ce mois."

--- a/packages/client/src/i18n/locales/it.json
+++ b/packages/client/src/i18n/locales/it.json
@@ -2694,7 +2694,9 @@
       "submit": "Invia richiesta",
       "cancel": "Annulla permesso",
       "emptyDesc": "Invia una richiesta di congedo per iniziare. Il tuo responsabile sarà notificato per l'approvazione.",
-      "request": "Richiedi congedo"
+      "request": "Richiedi congedo",
+      "submitFailed": "Impossibile inviare la richiesta di ferie. Verificare il saldo ferie e la politica.",
+      "retrySubmit": "Invia richiesta"
     },
     "teamCalendar": {
       "noLeaves": "Nessun permesso approvato per questo mese."

--- a/packages/client/src/i18n/locales/tr.json
+++ b/packages/client/src/i18n/locales/tr.json
@@ -2694,7 +2694,9 @@
       "submit": "Talebi gönder",
       "cancel": "İzni iptal et",
       "emptyDesc": "Başlamak için bir izin talebi gönderin. Yöneticiniz onay için bilgilendirilecektir.",
-      "request": "İzin talep et"
+      "request": "İzin talep et",
+      "submitFailed": "İzin talebi gönderilemedi. Lütfen izin bakiyenizi ve politikanızı kontrol edin.",
+      "retrySubmit": "Talebi gönder"
     },
     "teamCalendar": {
       "noLeaves": "Bu ay için onaylanmış izin yok."


### PR DESCRIPTION
## Problem

When a user creates a leave request, the UI performs two steps internally: create (Draft) → auto-submit (Pending). If the submit step fails (e.g. insufficient balance, no leave policy assigned), the modal closes silently with no error message. The leave is left stuck in **Draft** status with no way to retry or remove it from the UI.

## Root cause

In `my-leave-view.tsx`, `submitApp.mutate(data.id)` was called inside the `onSuccess` callback of the create mutation with no `onError` handler — any error from the submit call was silently swallowed.

Additionally, the leave list rendered no action buttons for Draft-status rows, so there was no way to retry submission after the fact.

## Changes

- Add `onError` handler to the auto-submit call to display a toast with the server-returned error message (e.g. `"Insufficient leave balance. Available: 0, Required: 3"`)
- Add a **Submit** (Send icon) action button on Draft-status rows so users can retry submission without recreating the request
- Add `submitFailed` and `retrySubmit` i18n keys for all five locales (en, tr, de, fr, it)

## Test plan

- [ ] Create a leave request as an employee with no leave policy assigned → error toast appears, leave shows Draft with a Submit button
- [ ] Fix the policy/balance, click the Submit button on the Draft row → leave transitions to Pending
- [ ] Create a leave request with sufficient balance → leave goes directly to Pending as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Users can now retry submission for draft leave requests via a new "Send" action button
  - Leave submission failures display error messages with retry options across supported languages (English, German, French, Italian, Turkish)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->