### PR TITLE
fix(hr): allow cancelling pending leave applications

### DIFF
--- a/packages/client/src/apps/hr/components/views/my-leave-view.tsx
+++ b/packages/client/src/apps/hr/components/views/my-leave-view.tsx
@@ -131,7 +131,7 @@ export function MyLeaveView({ employees }: { employees: HrEmployee[] }) {
                   <IconButton icon={<XCircle size={14} />} label={t('hr.actions.reject')} size={26} destructive onClick={() => rejectApp.mutate({ id: app.id })} />
                 </>
               )}
-              {app.status === 'approved' && app.employeeId === myEmployee?.id && (
+              {(app.status === 'approved' || app.status === 'pending') && app.employeeId === myEmployee?.id && (
                 <IconButton icon={<X size={14} />} label={t('hr.myLeave.cancel')} size={26} destructive onClick={() => cancelApp.mutate(app.id)} />
               )}
             </div>

--- a/packages/server/src/apps/hr/leave.service.ts
+++ b/packages/server/src/apps/hr/leave.service.ts
@@ -225,19 +225,21 @@ export async function cancelLeaveApplication(tenantId: string, id: string) {
 
   const [app] = await db.select().from(hrLeaveApplications)
     .where(and(eq(hrLeaveApplications.id, id), eq(hrLeaveApplications.tenantId, tenantId))).limit(1);
-  if (!app || app.status !== 'approved') return null;
+  if (!app || !['approved', 'pending'].includes(app.status)) return null;
 
-  // Restore balance
-  const [leaveType] = await db.select().from(hrLeaveTypes).where(eq(hrLeaveTypes.id, app.leaveTypeId)).limit(1);
-  if (leaveType) {
-    const currentYear = new Date(app.startDate).getFullYear();
-    await db.update(leaveBalances).set({
-      used: sql`GREATEST(${leaveBalances.used} - ${app.totalDays}, 0)`,
-      updatedAt: now,
-    }).where(and(
-      eq(leaveBalances.tenantId, tenantId), eq(leaveBalances.employeeId, app.employeeId),
-      eq(leaveBalances.leaveType, leaveType.slug), eq(leaveBalances.year, currentYear),
-    ));
+  // Restore balance only if approved (pending leaves never had balance deducted)
+  if (app.status === 'approved') {
+    const [leaveType] = await db.select().from(hrLeaveTypes).where(eq(hrLeaveTypes.id, app.leaveTypeId)).limit(1);
+    if (leaveType) {
+      const currentYear = new Date(app.startDate).getFullYear();
+      await db.update(leaveBalances).set({
+        used: sql`GREATEST(${leaveBalances.used} - ${app.totalDays}, 0)`,
+        updatedAt: now,
+      }).where(and(
+        eq(leaveBalances.tenantId, tenantId), eq(leaveBalances.employeeId, app.employeeId),
+        eq(leaveBalances.leaveType, leaveType.slug), eq(leaveBalances.year, currentYear),
+      ));
+    }
   }
 
   const [updated] = await db.update(hrLeaveApplications).set({


### PR DESCRIPTION
## Problem

A pending self-submitted leave with no assigned manager has no exit path from the UI:

- The **cancel button** only appears on *approved* leaves
- The **Approvals tab** filters out the requester's own records (correctly preventing self-approval)
- There is no delete endpoint

This leaves the leave permanently stuck in Pending with no action available to the requester.

## Changes

**Backend (`leave.service.ts`)**
- `cancelLeaveApplication` now accepts `pending` in addition to `approved`
- Balance restore is skipped for pending leaves since balance is only deducted upon approval

**Frontend (`my-leave-view.tsx`)**
- Cancel (X) button is now shown on `pending` rows owned by the current user, alongside the existing approved-leave cancel

## Test plan

- [ ] Submit a leave request as an employee with no manager assigned → leave goes to Pending → cancel button (X) is visible → clicking it transitions the leave to Cancelled
- [ ] Submit and get a leave approved → cancel button still works and correctly restores the balance
- [ ] Approvals tab still filters out self-submitted pending leaves (no self-approval possible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)