### PR TITLE
feat(work): table view, due dates & project in My Tasks, sort overdue

### DIFF
--- a/packages/client/src/apps/work/components/task-table-view.tsx
+++ b/packages/client/src/apps/work/components/task-table-view.tsx
@@ -1,0 +1,238 @@
+import { useState, memo } from 'react';
+import { Check, ChevronUp, ChevronDown, ChevronsUpDown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { Task, TaskProject, TenantUser } from '@atlas-platform/shared';
+import { isDoneStatus } from '@atlas-platform/shared';
+import { getDueBadgeClass, formatDueDate } from '../lib/helpers';
+import { Avatar } from '../../../components/ui/avatar';
+
+type SortKey = 'title' | 'project' | 'priority' | 'dueDate' | 'assignee';
+type SortDir = 'asc' | 'desc';
+
+const PRIORITY_ORDER: Record<string, number> = { urgent: 0, high: 1, medium: 2, low: 3, none: 4 };
+
+function SortIcon({ col, sortKey, sortDir }: { col: SortKey; sortKey: SortKey; sortDir: SortDir }) {
+  if (col !== sortKey) return <ChevronsUpDown size={11} style={{ opacity: 0.35 }} />;
+  return sortDir === 'asc' ? <ChevronUp size={11} /> : <ChevronDown size={11} />;
+}
+
+function TaskTableViewInner({
+  tasks,
+  projects,
+  members,
+  selectedTaskId,
+  selectedIds,
+  onSelectTask,
+  onComplete,
+  onCheckToggle,
+}: {
+  tasks: Task[];
+  projects: TaskProject[];
+  members?: TenantUser[];
+  selectedTaskId: string | null;
+  selectedIds: Set<string>;
+  onSelectTask: (id: string) => void;
+  onComplete: (id: string) => void;
+  onCheckToggle: (id: string) => void;
+}) {
+  const { t } = useTranslation();
+  const [sortKey, setSortKey] = useState<SortKey>('dueDate');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) setSortDir(d => d === 'asc' ? 'desc' : 'asc');
+    else { setSortKey(key); setSortDir('asc'); }
+  };
+
+  const sorted = [...tasks].sort((a, b) => {
+    let cmp = 0;
+    if (sortKey === 'title') {
+      cmp = a.title.localeCompare(b.title);
+    } else if (sortKey === 'project') {
+      const pa = projects.find(p => p.id === a.projectId)?.title ?? '';
+      const pb = projects.find(p => p.id === b.projectId)?.title ?? '';
+      cmp = pa.localeCompare(pb);
+    } else if (sortKey === 'priority') {
+      cmp = (PRIORITY_ORDER[a.priority] ?? 4) - (PRIORITY_ORDER[b.priority] ?? 4);
+    } else if (sortKey === 'dueDate') {
+      const da = a.dueDate ?? '9999';
+      const db = b.dueDate ?? '9999';
+      cmp = da.localeCompare(db);
+    } else if (sortKey === 'assignee') {
+      const ua = members?.find(m => m.userId === a.assigneeId)?.name ?? '';
+      const ub = members?.find(m => m.userId === b.assigneeId)?.name ?? '';
+      cmp = ua.localeCompare(ub);
+    }
+    return sortDir === 'asc' ? cmp : -cmp;
+  });
+
+  const thStyle: React.CSSProperties = {
+    padding: '6px var(--spacing-md)',
+    fontSize: 'var(--font-size-xs)',
+    fontWeight: 'var(--font-weight-semibold)',
+    color: 'var(--color-text-tertiary)',
+    fontFamily: 'var(--font-family)',
+    textAlign: 'left',
+    borderBottom: '1px solid var(--color-border-secondary)',
+    whiteSpace: 'nowrap',
+    userSelect: 'none',
+    cursor: 'pointer',
+  };
+
+  const tdStyle: React.CSSProperties = {
+    padding: '7px var(--spacing-md)',
+    fontSize: 'var(--font-size-sm)',
+    fontFamily: 'var(--font-family)',
+    borderBottom: '1px solid var(--color-border-secondary)',
+    verticalAlign: 'middle',
+  };
+
+  return (
+    <div style={{ overflow: 'auto', flex: 1 }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', tableLayout: 'fixed' }}>
+        <colgroup>
+          <col style={{ width: 36 }} />
+          <col style={{ width: 36 }} />
+          <col style={{ minWidth: 200 }} />
+          <col style={{ width: '18%' }} />
+          <col style={{ width: '10%' }} />
+          <col style={{ width: '13%' }} />
+          <col style={{ width: '16%' }} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th style={{ ...thStyle, cursor: 'default' }} />
+            <th style={{ ...thStyle, cursor: 'default' }} />
+            <th style={thStyle} onClick={() => handleSort('title')}>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                {t('tasks.fields.title')} <SortIcon col="title" sortKey={sortKey} sortDir={sortDir} />
+              </span>
+            </th>
+            <th style={thStyle} onClick={() => handleSort('project')}>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                {t('tasks.fields.project')} <SortIcon col="project" sortKey={sortKey} sortDir={sortDir} />
+              </span>
+            </th>
+            <th style={thStyle} onClick={() => handleSort('priority')}>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                {t('tasks.fields.priority')} <SortIcon col="priority" sortKey={sortKey} sortDir={sortDir} />
+              </span>
+            </th>
+            <th style={thStyle} onClick={() => handleSort('dueDate')}>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                {t('tasks.fields.dueDate')} <SortIcon col="dueDate" sortKey={sortKey} sortDir={sortDir} />
+              </span>
+            </th>
+            <th style={thStyle} onClick={() => handleSort('assignee')}>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                {t('tasks.fields.assignee')} <SortIcon col="assignee" sortKey={sortKey} sortDir={sortDir} />
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map(task => {
+            const project = task.projectId ? projects.find(p => p.id === task.projectId) : null;
+            const assignee = task.assigneeId ? members?.find(m => m.userId === task.assigneeId) : null;
+            const done = isDoneStatus(task.status);
+            const isSelected = selectedTaskId === task.id;
+
+            return (
+              <tr
+                key={task.id}
+                onClick={() => onSelectTask(task.id)}
+                style={{
+                  cursor: 'pointer',
+                  background: isSelected ? 'var(--color-surface-selected)' : undefined,
+                  transition: 'background 0.1s',
+                }}
+                onMouseEnter={e => { if (!isSelected) (e.currentTarget as HTMLElement).style.background = 'var(--color-surface-hover)'; }}
+                onMouseLeave={e => { if (!isSelected) (e.currentTarget as HTMLElement).style.background = ''; }}
+              >
+                {/* Checkbox */}
+                <td style={{ ...tdStyle, textAlign: 'center' }} onClick={e => { e.stopPropagation(); onCheckToggle(task.id); }}>
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.has(task.id)}
+                    onChange={() => {}}
+                    style={{ cursor: 'pointer', accentColor: 'var(--color-accent-primary)' }}
+                  />
+                </td>
+
+                {/* Complete button */}
+                <td style={{ ...tdStyle, textAlign: 'center' }} onClick={e => { e.stopPropagation(); onComplete(task.id); }}>
+                  <button
+                    className={`task-checkbox${done ? ' completed' : ''}`}
+                    style={{ margin: '0 auto' }}
+                    aria-label={done ? t('tasks.markIncomplete') : t('tasks.markComplete')}
+                  >
+                    {done && <Check size={12} color="var(--color-text-inverse)" strokeWidth={3} className="task-check-icon" />}
+                  </button>
+                </td>
+
+                {/* Title */}
+                <td style={{ ...tdStyle, color: 'var(--color-text-primary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    {task.priority !== 'none' && <div className={`task-priority-dot ${task.priority}`} style={{ flexShrink: 0 }} />}
+                    {task.icon && <span>{task.icon}</span>}
+                    <span className={done ? 'task-title-text completed' : ''} style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                      {task.title || t('tasks.untitled')}
+                    </span>
+                  </span>
+                </td>
+
+                {/* Project */}
+                <td style={{ ...tdStyle, color: 'var(--color-text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {project ? (
+                    <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                      {project.icon
+                        ? <span style={{ fontSize: 11 }}>{project.icon}</span>
+                        : <div className="task-project-dot" style={{ background: project.color, flexShrink: 0 }} />}
+                      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{project.title}</span>
+                    </span>
+                  ) : <span style={{ color: 'var(--color-text-tertiary)' }}>—</span>}
+                </td>
+
+                {/* Priority */}
+                <td style={{ ...tdStyle, color: 'var(--color-text-secondary)' }}>
+                  {task.priority !== 'none'
+                    ? <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                        <div className={`task-priority-dot ${task.priority}`} />
+                        {t(`tasks.priority.${task.priority}`)}
+                      </span>
+                    : <span style={{ color: 'var(--color-text-tertiary)' }}>—</span>}
+                </td>
+
+                {/* Due date */}
+                <td style={tdStyle}>
+                  {task.dueDate
+                    ? <span className={getDueBadgeClass(task.dueDate)}>{formatDueDate(task.dueDate, t)}</span>
+                    : <span style={{ color: 'var(--color-text-tertiary)' }}>—</span>}
+                </td>
+
+                {/* Assignee */}
+                <td style={tdStyle}>
+                  {assignee
+                    ? <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                        <Avatar name={assignee.name} email={assignee.email} size={20} />
+                        <span style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {assignee.name || assignee.email}
+                        </span>
+                      </span>
+                    : <span style={{ color: 'var(--color-text-tertiary)' }}>—</span>}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {sorted.length === 0 && (
+        <div style={{ padding: 'var(--spacing-2xl)', textAlign: 'center', color: 'var(--color-text-tertiary)', fontSize: 'var(--font-size-sm)', fontFamily: 'var(--font-family)' }}>
+          {t('tasks.noTasks')}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const TaskTableView = memo(TaskTableViewInner);

--- a/packages/client/src/apps/work/components/work-tasks-view.tsx
+++ b/packages/client/src/apps/work/components/work-tasks-view.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import {
   Search, Inbox, Star, Calendar, Coffee,
   CircleDot, Moon, X, Trash2,
-  LayoutList, LayoutGrid, User,
+  LayoutList, LayoutGrid, Table2, User,
   Eye, Users,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -30,6 +30,7 @@ import { CalendarView } from './calendar-view';
 import { TaskDetailPanel } from './task-detail-panel';
 import { KanbanBoard } from './kanban-board';
 import { TaskListView } from './task-list-view';
+import { TaskTableView } from './task-table-view';
 import '../../../styles/tasks.css';
 
 export type WorkView = 'my' | 'assigned' | 'created' | 'all' | `project:${string}`;
@@ -55,7 +56,7 @@ export function WorkTasksView({ view, title }: Props) {
   const [showSearch, setShowSearch] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [visibilityFilter, setVisibilityFilter] = useState<'all' | 'mine' | 'team'>('all');
-  const [viewMode, setViewMode] = useState<'list' | 'board'>(tasksSettings.viewMode || 'list');
+  const [viewMode, setViewMode] = useState<'list' | 'board' | 'table'>(tasksSettings.viewMode || 'list');
   const canShowBoard = view === 'my';
 
   useEffect(() => {
@@ -158,6 +159,7 @@ export function WorkTasksView({ view, title }: Props) {
       else inbox.push(task);
     }
     const groups: { label: string; icon: typeof Inbox; color: string; tasks: Task[]; noHeader?: boolean }[] = [];
+    overdue.sort((a, b) => (a.dueDate ?? '').localeCompare(b.dueDate ?? ''));
     if (overdue.length > 0) groups.push({ label: t('tasks.overdue'), icon: Calendar, color: '#ef4444', tasks: overdue });
     if (inbox.length > 0) groups.push({ label: t('tasks.unscheduled'), icon: Inbox, color: '#3b82f6', tasks: inbox, noHeader: true });
     if (today.length > 0) groups.push({ label: t('tasks.todayLabel'), icon: Star, color: '#f59e0b', tasks: today });
@@ -171,11 +173,9 @@ export function WorkTasksView({ view, title }: Props) {
     return view.startsWith('project:') || view === 'all' || view === 'assigned' || view === 'created';
   }, [view]);
 
-  const showProjectInList = useMemo(() => {
-    return view === 'all' || view === 'assigned' || view === 'created';
-  }, [view]);
+  const showProjectInList = true;
 
-  const showDueDateInList = view !== 'my';
+  const showDueDateInList = true;
 
   const selectedTask = useMemo(
     () => displayTasks.find(t => t.id === selectedTaskId) ?? null,
@@ -354,18 +354,22 @@ export function WorkTasksView({ view, title }: Props) {
                 label={allVisibleSelected ? t('tasks.deselectAll') : t('tasks.selectAll')} size={28} onClick={toggleSelectAll}
               />
             )}
-            {canShowBoard && (
-              <div className="tasks-view-toggle">
-                <button className={`tasks-view-toggle-btn${viewMode === 'list' ? ' active' : ''}`}
-                  onClick={() => { setViewMode('list'); tasksSettings.setViewMode('list'); }} title={t('tasks.listView')}>
-                  <LayoutList size={14} />
-                </button>
+            <div className="tasks-view-toggle">
+              <button className={`tasks-view-toggle-btn${viewMode === 'list' ? ' active' : ''}`}
+                onClick={() => { setViewMode('list'); tasksSettings.setViewMode('list'); }} title={t('tasks.listView')}>
+                <LayoutList size={14} />
+              </button>
+              {canShowBoard && (
                 <button className={`tasks-view-toggle-btn${viewMode === 'board' ? ' active' : ''}`}
                   onClick={() => { setViewMode('board'); tasksSettings.setViewMode('board'); }} title={t('tasks.boardView')}>
                   <LayoutGrid size={14} />
                 </button>
-              </div>
-            )}
+              )}
+              <button className={`tasks-view-toggle-btn${viewMode === 'table' ? ' active' : ''}`}
+                onClick={() => { setViewMode('table'); tasksSettings.setViewMode('table'); }} title={t('tasks.tableView')}>
+                <Table2 size={14} />
+              </button>
+            </div>
             {showSearch ? (
               <div className="tasks-search-bar">
                 <Search size={13} color="var(--color-text-tertiary)" />
@@ -397,7 +401,23 @@ export function WorkTasksView({ view, title }: Props) {
         )}
 
         <div className="tasks-content">
-          {viewMode === 'board' && canShowBoard ? (
+          {viewMode === 'table' ? (
+            <>
+              <TaskTableView
+                tasks={displayTasks.filter(t => t.type !== 'heading')}
+                projects={projects}
+                members={tenantMembers}
+                selectedTaskId={selectedTaskId}
+                selectedIds={selectedIds}
+                onSelectTask={setSelectedTaskId}
+                onComplete={handleComplete}
+                onCheckToggle={toggleSelectOne}
+              />
+              {selectedTask && selectedTask.type !== 'heading' && (
+                <TaskDetailPanel task={selectedTask} projects={projects} members={tenantMembers} allTasks={allTasks} onClose={() => setSelectedTaskId(null)} />
+              )}
+            </>
+          ) : viewMode === 'board' && canShowBoard ? (
             <>
               <KanbanBoard tasks={displayTasks} projects={projects} onComplete={handleComplete} onSelectTask={(id) => setSelectedTaskId(id)} />
               {selectedTask && selectedTask.type !== 'heading' && (

--- a/packages/client/src/apps/work/settings-store.ts
+++ b/packages/client/src/apps/work/settings-store.ts
@@ -3,7 +3,7 @@ import { createAppSettingsHook } from '../../lib/create-app-settings-store';
 export type TaskDefaultView = 'inbox' | 'today' | 'anytime';
 export type TaskCompletedBehavior = 'fade' | 'move' | 'hide';
 export type TaskSortOrder = 'manual' | 'priority' | 'dueDate' | 'title' | 'created';
-export type TaskViewMode = 'list' | 'board';
+export type TaskViewMode = 'list' | 'board' | 'table';
 
 interface TasksSettings {
   defaultView: TaskDefaultView;

--- a/packages/client/src/i18n/locales/de.json
+++ b/packages/client/src/i18n/locales/de.json
@@ -842,6 +842,7 @@
     "notes": "Notizen",
     "when": "Wann",
     "priority": {
+      "urgent": "Dringend",
       "high": "Hoch",
       "medium": "Mittel",
       "low": "Niedrig",
@@ -1081,7 +1082,15 @@
     "widgetDueToday": "heute fällig",
     "widgetOverdue": "überfällig",
     "widgetCompleted": "diese Woche",
-    "download": "Herunterladen"
+    "download": "Herunterladen",
+    "tableView": "Tabellenansicht",
+    "fields": {
+      "title": "Titel",
+      "project": "Projekt",
+      "priority": "Priorität",
+      "dueDate": "Fälligkeitsdatum",
+      "assignee": "Zugewiesen"
+    }
   },
   "errors": {
     "recipientRequired": "Mindestens ein Empfänger ist erforderlich",

--- a/packages/client/src/i18n/locales/en.json
+++ b/packages/client/src/i18n/locales/en.json
@@ -869,6 +869,7 @@
     "notes": "Notes",
     "when": "When",
     "priority": {
+      "urgent": "Urgent",
       "high": "High",
       "medium": "Medium",
       "low": "Low",
@@ -1108,7 +1109,15 @@
     "widgetDueToday": "due today",
     "widgetOverdue": "overdue",
     "widgetCompleted": "this week",
-    "download": "Download"
+    "download": "Download",
+    "tableView": "Table view",
+    "fields": {
+      "title": "Title",
+      "project": "Project",
+      "priority": "Priority",
+      "dueDate": "Due date",
+      "assignee": "Assignee"
+    }
   },
   "errors": {
     "recipientRequired": "At least one recipient is required",

--- a/packages/client/src/i18n/locales/fr.json
+++ b/packages/client/src/i18n/locales/fr.json
@@ -842,9 +842,10 @@
     "notes": "Notes",
     "when": "Quand",
     "priority": {
-      "high": "Haute",
+      "urgent": "Urgent",
+      "high": "Élevée",
       "medium": "Moyenne",
-      "low": "Basse",
+      "low": "Faible",
       "none": "Aucune"
     },
     "dueDate": "Date d'échéance",
@@ -1081,7 +1082,15 @@
     "widgetDueToday": "à faire aujourd'hui",
     "widgetOverdue": "en retard",
     "widgetCompleted": "cette semaine",
-    "download": "Télécharger"
+    "download": "Télécharger",
+    "tableView": "Vue tableau",
+    "fields": {
+      "title": "Titre",
+      "project": "Projet",
+      "priority": "Priorité",
+      "dueDate": "Date limite",
+      "assignee": "Assigné"
+    }
   },
   "errors": {
     "recipientRequired": "Au moins un destinataire est requis",

--- a/packages/client/src/i18n/locales/it.json
+++ b/packages/client/src/i18n/locales/it.json
@@ -842,6 +842,7 @@
     "notes": "Note",
     "when": "Quando",
     "priority": {
+      "urgent": "Urgente",
       "high": "Alta",
       "medium": "Media",
       "low": "Bassa",
@@ -1081,7 +1082,15 @@
     "widgetDueToday": "in scadenza oggi",
     "widgetOverdue": "in ritardo",
     "widgetCompleted": "questa settimana",
-    "download": "Scarica"
+    "download": "Scarica",
+    "tableView": "Vista tabella",
+    "fields": {
+      "title": "Titolo",
+      "project": "Progetto",
+      "priority": "Priorità",
+      "dueDate": "Scadenza",
+      "assignee": "Assegnato"
+    }
   },
   "errors": {
     "recipientRequired": "È necessario almeno un destinatario",

--- a/packages/client/src/i18n/locales/tr.json
+++ b/packages/client/src/i18n/locales/tr.json
@@ -842,6 +842,7 @@
     "notes": "Notlar",
     "when": "Ne zaman",
     "priority": {
+      "urgent": "Acil",
       "high": "Yüksek",
       "medium": "Orta",
       "low": "Düşük",
@@ -1081,7 +1082,15 @@
     "widgetDueToday": "bugün bitiyor",
     "widgetOverdue": "gecikmiş",
     "widgetCompleted": "bu hafta",
-    "download": "İndir"
+    "download": "İndir",
+    "tableView": "Tablo görünümü",
+    "fields": {
+      "title": "Başlık",
+      "project": "Proje",
+      "priority": "Öncelik",
+      "dueDate": "Bitiş tarihi",
+      "assignee": "Atanan"
+    }
   },
   "errors": {
     "recipientRequired": "En az bir alıcı gereklidir",


### PR DESCRIPTION
## Summary

- **Table view** — a new Table2 toggle added to the view toolbar (available on all work views, not just My Tasks). Renders tasks in a sortable table with columns for title, project, priority, due date, and assignee. Clicking a row opens the task detail panel. Column sorting is bi-directional.
- **Due dates in My Tasks** — `showDueDateInList` was hardcoded to `false` for the `my` view. Now always visible, giving immediate timing context per task.
- **Project name in My Tasks** — `showProjectInList` was also hidden for the `my` view. Now always visible so you can see which project each task belongs to without opening the detail panel.
- **Overdue tasks sorted by date** — the Overdue group now sorts tasks ascending by due date (oldest first = most urgent first) instead of API order.
- **i18n** — added `tasks.tableView`, `tasks.fields.*` (title, project, priority, dueDate, assignee) and `tasks.priority.*` keys for all five locales (en, tr, de, fr, it).

## Test plan

- [ ] My Tasks list view shows due date and project name on each task row
- [ ] Overdue group shows oldest-due tasks at the top
- [ ] Table toggle (grid-table icon) appears in the toolbar on all work views
- [ ] Table view renders all tasks with sortable columns — clicking a column header toggles asc/desc
- [ ] Clicking a table row opens the task detail panel
- [ ] Checkbox column works for bulk selection in table view
- [ ] Complete button (circle) in table view marks task done
- [ ] View mode persists across navigation (stored in settings)
- [ ] Board toggle still only appears on My Tasks view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added table view mode for tasks with column sorting capabilities
  * Introduced "Urgent" priority level to task options
  * Extended language support for table view labels and field names in German, English, French, Italian, and Turkish

<!-- end of auto-generated comment: release notes by coderabbit.ai -->