### PR TITLE
fix(i18n): add missing common.noResults and common.navigation keys

### DIFF
--- a/packages/client/src/i18n/locales/de.json
+++ b/packages/client/src/i18n/locales/de.json
@@ -85,7 +85,9 @@
       "of": "von",
       "clear": "Zurücksetzen"
     },
-    "signOut": "Abmelden"
+    "signOut": "Abmelden",
+    "noResults": "Keine Ergebnisse",
+    "navigation": "Navigation"
   },
   "auth": {
     "appName": "Atlas",

--- a/packages/client/src/i18n/locales/en.json
+++ b/packages/client/src/i18n/locales/en.json
@@ -85,7 +85,9 @@
       "of": "of",
       "clear": "Clear"
     },
-    "signOut": "Sign out"
+    "signOut": "Sign out",
+    "noResults": "No results",
+    "navigation": "Navigation"
   },
   "auth": {
     "appName": "Atlas",

--- a/packages/client/src/i18n/locales/fr.json
+++ b/packages/client/src/i18n/locales/fr.json
@@ -85,7 +85,9 @@
       "of": "sur",
       "clear": "Effacer"
     },
-    "signOut": "Se déconnecter"
+    "signOut": "Se déconnecter",
+    "noResults": "Aucun résultat",
+    "navigation": "Navigation"
   },
   "auth": {
     "appName": "Atlas",

--- a/packages/client/src/i18n/locales/it.json
+++ b/packages/client/src/i18n/locales/it.json
@@ -85,7 +85,9 @@
       "of": "di",
       "clear": "Cancella"
     },
-    "signOut": "Esci"
+    "signOut": "Esci",
+    "noResults": "Nessun risultato",
+    "navigation": "Navigazione"
   },
   "auth": {
     "appName": "Atlas",

--- a/packages/client/src/i18n/locales/tr.json
+++ b/packages/client/src/i18n/locales/tr.json
@@ -85,7 +85,9 @@
       "of": "/",
       "clear": "Temizle"
     },
-    "signOut": "Çıkış yap"
+    "signOut": "Çıkış yap",
+    "noResults": "Sonuç bulunamadı",
+    "navigation": "Gezinme"
   },
   "auth": {
     "appName": "Atlas",


### PR DESCRIPTION
## Problem

The command palette renders `common.noResults` and `common.navigation` as raw key strings instead of translated text in all non-English locales (tr, de, fr, it). Both keys exist in the component but were never added to the locale files.

## Changes

Added `common.noResults` and `common.navigation` to all five locale files:

| Locale | noResults | navigation |
|--------|-----------|------------|
| en | No results | Navigation |
| tr | Sonuç bulunamadı | Gezinme |
| de | Keine Ergebnisse | Navigation |
| fr | Aucun résultat | Navigation |
| it | Nessun risultato | Navigazione |

## Test plan

- [ ] Open the command palette (⌘K) with a non-English locale set
- [ ] Type a search query that returns no results → "No results" (translated) appears instead of `common.noResults`
- [ ] The navigation section header renders correctly instead of `common.navigation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)