### PR TITLE
feat(work): task-level time tracking (timer + manual log)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19397,7 +19397,7 @@
     },
     "packages/client": {
       "name": "@atlas-platform/client",
-      "version": "2.6.2",
+      "version": "2.7.1",
       "dependencies": {
         "@atlas-platform/shared": "*",
         "@dnd-kit/core": "^6.3.1",
@@ -19763,7 +19763,7 @@
     },
     "packages/server": {
       "name": "@atlas-platform/server",
-      "version": "2.6.2",
+      "version": "2.7.1",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.47",
         "@ai-sdk/cohere": "^3.0.21",
@@ -20608,7 +20608,7 @@
     },
     "packages/shared": {
       "name": "@atlas-platform/shared",
-      "version": "2.6.2",
+      "version": "2.7.1",
       "dependencies": {
         "zod": "^3.24.0"
       },

--- a/packages/client/src/apps/work/components/task-detail-panel.tsx
+++ b/packages/client/src/apps/work/components/task-detail-panel.tsx
@@ -11,6 +11,7 @@ import { TaskNotesEditor } from './task-notes-editor';
 import { SubtaskSection } from './subtask-section';
 import { DependencySection } from './dependency-section';
 import { AttachmentSection } from './attachment-section';
+import { TaskTimeSection } from './task-time-section';
 import { CommentSection } from './comment-section';
 import { ActivitySection } from './activity-section';
 import { EmojiPicker } from '../../../components/shared/emoji-picker';
@@ -300,6 +301,9 @@ export function TaskDetailPanel({
 
         {/* Attachments */}
         <AttachmentSection taskId={task.id} />
+
+        {/* Time tracking */}
+        <TaskTimeSection task={task} projects={projects} />
 
         {/* Rich notes editor (below details) */}
         <div style={{ paddingTop: 16 }}>

--- a/packages/client/src/apps/work/components/task-item.tsx
+++ b/packages/client/src/apps/work/components/task-item.tsx
@@ -1,12 +1,13 @@
 import { useState, useRef, useEffect, memo } from 'react';
 import {
-  Check, ChevronRight, GripVertical, Hash, Repeat, FileText,
+  Check, ChevronRight, GripVertical, Hash, Repeat, FileText, Play, Square,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { Task, TaskProject, TenantUser } from '@atlas-platform/shared';
 import { isDoneStatus } from '@atlas-platform/shared';
 import { useTasksSettingsStore } from '../settings-store';
 import { useAppActions } from '../../../hooks/use-app-permissions';
+import { useActiveTimer, useStartTaskTimer, useStopTimer } from '../hooks';
 import { useAuthStore } from '../../../stores/auth-store';
 import { getDueBadgeClass, formatDueDate } from '../lib/helpers';
 import { WhenBadge } from './when-badge';
@@ -58,8 +59,18 @@ function TaskItemInner({
 }) {
   const { t } = useTranslation();
   const tasksSettings = useTasksSettingsStore();
-  const { canEdit } = useAppActions('work');
+  const { canEdit, canCreate } = useAppActions('work');
   const currentUserId = useAuthStore((s) => s.account?.userId);
+  const { data: activeTimer } = useActiveTimer();
+  const startTimer = useStartTaskTimer();
+  const stopTimer = useStopTimer();
+  const isTimerRunning = activeTimer?.taskId === task.id;
+
+  const handleTimerToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isTimerRunning) stopTimer.mutate(task.id);
+    else if (task.projectId) startTimer.mutate({ taskId: task.id, projectId: task.projectId });
+  };
   const [completing, setCompleting] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [editTitle, setEditTitle] = useState(task.title);
@@ -237,6 +248,26 @@ function TaskItemInner({
         <span style={{ fontSize: 10, color: 'var(--color-text-tertiary)', fontFamily: 'var(--font-family)', flexShrink: 0 }}>
           {t('tasks.createdBy', { name: task.creatorName })}
         </span>
+      )}
+
+      {/* Time-tracking toggle — only tasks attached to a project are trackable.
+          Shows on hover via .task-track-btn unless the timer is running here. */}
+      {canCreate && task.projectId && (
+        <button
+          type="button"
+          className={`task-track-btn${isTimerRunning ? ' running' : ''}`}
+          onClick={handleTimerToggle}
+          title={isTimerRunning ? t('tasks.stopTimer', 'Stop timer') : t('tasks.startTimer', 'Start timer')}
+          aria-label={isTimerRunning ? t('tasks.stopTimer', 'Stop timer') : t('tasks.startTimer', 'Start timer')}
+          style={{
+            flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+            width: 22, height: 22, borderRadius: 6, cursor: 'pointer',
+            border: 'none', background: 'transparent',
+            color: isTimerRunning ? 'var(--color-danger)' : 'var(--color-text-tertiary)',
+          }}
+        >
+          {isTimerRunning ? <Square size={13} /> : <Play size={13} />}
+        </button>
       )}
 
       {/* Notes indicator (respects settings) */}

--- a/packages/client/src/apps/work/components/task-time-section.tsx
+++ b/packages/client/src/apps/work/components/task-time-section.tsx
@@ -1,0 +1,234 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Play, Square, Plus, X, Clock } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { Task, TaskProject } from '@atlas-platform/shared';
+import {
+  useTaskTimeEntries, useLogTaskTime, useDeleteTaskTimeEntry,
+  useActiveTimer, useStartTaskTimer, useStopTimer,
+} from '../hooks';
+import { useAppActions } from '../../../hooks/use-app-permissions';
+import { IconButton } from '../../../components/ui/icon-button';
+import { Select } from '../../../components/ui/select';
+
+// minutes → "1h 30m" / "45m" / "0m"
+function formatMinutes(min: number): string {
+  const m = Math.max(0, Math.round(min));
+  const h = Math.floor(m / 60);
+  const rem = m % 60;
+  if (h && rem) return `${h}h ${rem}m`;
+  if (h) return `${h}h`;
+  return `${rem}m`;
+}
+
+// Live elapsed since an ISO start, as "H:MM:SS".
+function elapsedLabel(startedAtIso: string, nowMs: number): string {
+  const secs = Math.max(0, Math.floor((nowMs - new Date(startedAtIso).getTime()) / 1000));
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = secs % 60;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${h}:${pad(m)}:${pad(s)}`;
+}
+
+export function TaskTimeSection({ task, projects }: { task: Task; projects: TaskProject[] }) {
+  const { t } = useTranslation();
+  const { canCreate, canDelete } = useAppActions('work');
+  const { data } = useTaskTimeEntries(task.id);
+  const { data: activeTimer } = useActiveTimer();
+  const logTime = useLogTaskTime();
+  const deleteEntry = useDeleteTaskTimeEntry();
+  const startTimer = useStartTaskTimer();
+  const stopTimer = useStopTimer();
+
+  // When the task has no project, the user must pick one before tracking.
+  const [pickedProjectId, setPickedProjectId] = useState<string | null>(null);
+  const effectiveProjectId = task.projectId ?? pickedProjectId;
+
+  const [showManual, setShowManual] = useState(false);
+  const [hours, setHours] = useState('');
+  const [minutes, setMinutes] = useState('');
+  const [notes, setNotes] = useState('');
+
+  // Tick once a second only while this task's timer is running.
+  const isRunningHere = activeTimer?.taskId === task.id;
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    if (!isRunningHere) return;
+    const id = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [isRunningHere]);
+
+  const entries = data?.entries ?? [];
+  const totalMinutes = data?.totalMinutes ?? 0;
+
+  const projectOptions = useMemo(
+    () => projects.filter(p => !p.isArchived).map(p => ({ value: p.id, label: p.title })),
+    [projects],
+  );
+
+  const needsProject = !effectiveProjectId;
+
+  const handleStart = () => {
+    if (!effectiveProjectId) return;
+    startTimer.mutate({ taskId: task.id, projectId: effectiveProjectId });
+  };
+
+  const handleStop = () => {
+    stopTimer.mutate(task.id);
+  };
+
+  const handleLogManual = () => {
+    const total = (parseInt(hours || '0', 10) * 60) + parseInt(minutes || '0', 10);
+    if (total <= 0 || !effectiveProjectId) return;
+    logTime.mutate(
+      { taskId: task.id, projectId: effectiveProjectId, durationMinutes: total, notes: notes.trim() || null },
+      {
+        onSuccess: () => {
+          setHours(''); setMinutes(''); setNotes(''); setShowManual(false);
+        },
+      },
+    );
+  };
+
+  return (
+    <div style={{ padding: 'var(--spacing-lg)', borderTop: '1px solid var(--color-border-secondary)' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 'var(--spacing-md)' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontWeight: 600, fontSize: 13, color: 'var(--color-text-secondary)' }}>
+          <Clock size={15} />
+          <span>{t('tasks.timeTracking', 'Time tracking')}</span>
+          {totalMinutes > 0 && (
+            <span style={{ color: 'var(--color-text-primary)', fontVariantNumeric: 'tabular-nums' }}>
+              · {formatMinutes(totalMinutes)}
+            </span>
+          )}
+        </div>
+        {canCreate && !needsProject && (
+          <IconButton
+            icon={<Plus size={16} />}
+            label={t('tasks.logTime', 'Log time')}
+            onClick={() => setShowManual(v => !v)}
+          />
+        )}
+      </div>
+
+      {/* Inline project picker — tracking requires a project. */}
+      {needsProject ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+            {t('tasks.attachProjectToTrack', 'Attach this task to a project to track time')}
+          </span>
+          <Select
+            value=""
+            onChange={(value) => setPickedProjectId(value || null)}
+            options={[{ value: '', label: t('tasks.selectProject', 'Select a project…') }, ...projectOptions]}
+          />
+        </div>
+      ) : (
+        <>
+          {/* Live timer controls */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            {isRunningHere ? (
+              <>
+                <button
+                  type="button"
+                  onClick={handleStop}
+                  disabled={stopTimer.isPending}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px',
+                    borderRadius: 'var(--radius-md)', border: 'none', cursor: 'pointer',
+                    background: 'var(--color-danger)', color: '#fff', fontSize: 13, fontWeight: 500,
+                  }}
+                >
+                  <Square size={14} /> {t('tasks.stopTimer', 'Stop')}
+                </button>
+                <span style={{ fontVariantNumeric: 'tabular-nums', fontSize: 15, fontWeight: 600, color: 'var(--color-text-primary)' }}>
+                  {activeTimer && elapsedLabel(activeTimer.startedAt, nowMs)}
+                </span>
+              </>
+            ) : (
+              canCreate && (
+                <button
+                  type="button"
+                  onClick={handleStart}
+                  disabled={startTimer.isPending}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px',
+                    borderRadius: 'var(--radius-md)', border: '1px solid var(--color-border-primary)',
+                    cursor: 'pointer', background: 'var(--color-bg-secondary)',
+                    color: 'var(--color-text-primary)', fontSize: 13, fontWeight: 500,
+                  }}
+                >
+                  <Play size={14} /> {t('tasks.startTimer', 'Start timer')}
+                </button>
+              )
+            )}
+            {activeTimer && !isRunningHere && (
+              <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+                {t('tasks.timerRunningElsewhere', 'A timer is running on another task')}
+              </span>
+            )}
+          </div>
+
+          {/* Manual entry form */}
+          {showManual && canCreate && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 'var(--spacing-md)' }}>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                <input
+                  type="number" min={0} placeholder="0" value={hours}
+                  onChange={(e) => setHours(e.target.value)}
+                  style={{ width: 56, padding: '6px 8px', borderRadius: 'var(--radius-md)', border: '1px solid var(--color-border-primary)', background: 'var(--color-bg-primary)', color: 'var(--color-text-primary)' }}
+                />
+                <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>h</span>
+                <input
+                  type="number" min={0} max={59} placeholder="0" value={minutes}
+                  onChange={(e) => setMinutes(e.target.value)}
+                  style={{ width: 56, padding: '6px 8px', borderRadius: 'var(--radius-md)', border: '1px solid var(--color-border-primary)', background: 'var(--color-bg-primary)', color: 'var(--color-text-primary)' }}
+                />
+                <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>m</span>
+                <input
+                  type="text" placeholder={t('tasks.timeNotePlaceholder', 'Note (optional)')} value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  style={{ flex: 1, padding: '6px 8px', borderRadius: 'var(--radius-md)', border: '1px solid var(--color-border-primary)', background: 'var(--color-bg-primary)', color: 'var(--color-text-primary)' }}
+                />
+                <button
+                  type="button" onClick={handleLogManual} disabled={logTime.isPending}
+                  style={{ padding: '6px 12px', borderRadius: 'var(--radius-md)', border: 'none', cursor: 'pointer', background: 'var(--color-accent)', color: '#fff', fontSize: 13, fontWeight: 500 }}
+                >
+                  {t('common.add', 'Add')}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Entry list */}
+          {entries.length > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginTop: 'var(--spacing-md)' }}>
+              {entries.map(entry => (
+                <div key={entry.id} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '6px 0', fontSize: 13 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
+                    <span style={{ fontVariantNumeric: 'tabular-nums', fontWeight: 600, color: 'var(--color-text-primary)' }}>
+                      {formatMinutes(entry.durationMinutes)}
+                    </span>
+                    <span style={{ color: 'var(--color-text-tertiary)' }}>{entry.workDate}</span>
+                    {entry.notes && (
+                      <span style={{ color: 'var(--color-text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {entry.notes}
+                      </span>
+                    )}
+                  </div>
+                  {canDelete && (
+                    <IconButton
+                      icon={<X size={14} />}
+                      label={t('common.delete', 'Delete')}
+                      onClick={() => deleteEntry.mutate({ taskId: task.id, entryId: entry.id })}
+                    />
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/apps/work/hooks.ts
+++ b/packages/client/src/apps/work/hooks.ts
@@ -1087,3 +1087,162 @@ export function useReorderTaskStatuses() {
     },
   });
 }
+
+// ─── Task Time Tracking Hooks ───────────────────────────────────────
+
+export interface TaskTimeEntry {
+  id: string;
+  taskId: string;
+  projectId: string;
+  userId: string;
+  durationMinutes: number;
+  workDate: string;
+  startTime: string | null;
+  endTime: string | null;
+  notes: string | null;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ActiveTimer {
+  id: string;
+  taskId: string;
+  projectId: string;
+  startedAt: string;
+  note: string | null;
+}
+
+interface TaskTimeResponse {
+  entries: TaskTimeEntry[];
+  totalMinutes: number;
+}
+
+export function useTaskTimeEntries(taskId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.work.tasks.time(taskId!),
+    queryFn: async () => {
+      const { data } = await api.get(`/work/tasks/${taskId}/time-entries`);
+      return data.data as TaskTimeResponse;
+    },
+    enabled: !!taskId,
+    staleTime: 10_000,
+  });
+}
+
+export function useLogTaskTime() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ taskId, ...input }: {
+      taskId: string;
+      projectId?: string | null;
+      durationMinutes: number;
+      workDate?: string;
+      startTime?: string | null;
+      endTime?: string | null;
+      notes?: string | null;
+      tags?: string[];
+    }) => {
+      const { data } = await api.post(`/work/tasks/${taskId}/time-entries`, input);
+      return data.data as TaskTimeEntry;
+    },
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.work.tasks.time(vars.taskId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.work.tasks.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.work.projects.all });
+    },
+  });
+}
+
+export function useUpdateTaskTimeEntry() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ taskId, entryId, ...input }: {
+      taskId: string;
+      entryId: string;
+      durationMinutes?: number;
+      workDate?: string;
+      startTime?: string | null;
+      endTime?: string | null;
+      notes?: string | null;
+      tags?: string[];
+    }) => {
+      const { data } = await api.patch(`/work/tasks/${taskId}/time-entries/${entryId}`, input);
+      return data.data as TaskTimeEntry;
+    },
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.work.tasks.time(vars.taskId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.work.projects.all });
+    },
+  });
+}
+
+export function useDeleteTaskTimeEntry() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ taskId, entryId }: { taskId: string; entryId: string }) => {
+      await api.delete(`/work/tasks/${taskId}/time-entries/${entryId}`);
+      return taskId;
+    },
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.work.tasks.time(vars.taskId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.work.tasks.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.work.projects.all });
+    },
+  });
+}
+
+export function useActiveTimer() {
+  return useQuery({
+    queryKey: queryKeys.work.timer,
+    queryFn: async () => {
+      const { data } = await api.get('/work/timer/active');
+      return data.data as ActiveTimer | null;
+    },
+    // Light polling so a timer started elsewhere stays in sync.
+    refetchInterval: 30_000,
+    staleTime: 5_000,
+  });
+}
+
+export function useStartTaskTimer() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ taskId, projectId, note }: { taskId: string; projectId?: string | null; note?: string | null }) => {
+      const { data } = await api.post(`/work/tasks/${taskId}/timer/start`, { projectId, note });
+      return data.data as ActiveTimer;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.work.timer });
+      queryClient.invalidateQueries({ queryKey: queryKeys.work.tasks.all });
+    },
+  });
+}
+
+export function useStopTimer() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (taskId?: string) => {
+      const { data } = await api.post('/work/timer/stop', {});
+      return { entry: data.data as TaskTimeEntry, taskId };
+    },
+    onSuccess: ({ taskId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.work.timer });
+      queryClient.invalidateQueries({ queryKey: queryKeys.work.tasks.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.work.projects.all });
+      if (taskId) queryClient.invalidateQueries({ queryKey: queryKeys.work.tasks.time(taskId) });
+    },
+  });
+}
+
+export function useCancelTimer() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      await api.post('/work/timer/cancel', {});
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.work.timer });
+    },
+  });
+}

--- a/packages/client/src/config/query-keys.ts
+++ b/packages/client/src/config/query-keys.ts
@@ -286,7 +286,9 @@ export const queryKeys = {
       attachments: (taskId: string) => ['work', 'tasks', 'attachments', taskId] as const,
       dependencies: (taskId: string) => ['work', 'tasks', 'dependencies', taskId] as const,
       blockedIds: ['work', 'tasks', 'blocked-ids'] as const,
+      time: (taskId: string) => ['work', 'tasks', 'time', taskId] as const,
     },
+    timer: ['work', 'timer', 'active'] as const,
     projects: {
       all: ['work', 'projects'] as const,
       dashboard: ['work', 'projects', 'dashboard'] as const,

--- a/packages/client/src/i18n/locales/de.json
+++ b/packages/client/src/i18n/locales/de.json
@@ -87,7 +87,8 @@
     },
     "signOut": "Abmelden",
     "noResults": "Keine Ergebnisse",
-    "navigation": "Navigation"
+    "navigation": "Navigation",
+    "add": "Hinzufügen"
   },
   "auth": {
     "appName": "Atlas",
@@ -1111,7 +1112,15 @@
       "priority": "Priorität",
       "dueDate": "Fälligkeitsdatum",
       "assignee": "Zuständig"
-    }
+    },
+    "timeTracking": "Zeiterfassung",
+    "startTimer": "Timer starten",
+    "stopTimer": "Timer stoppen",
+    "logTime": "Zeit erfassen",
+    "attachProjectToTrack": "Verknüpfe diese Aufgabe mit einem Projekt, um die Zeit zu erfassen",
+    "selectProject": "Projekt auswählen…",
+    "timerRunningElsewhere": "Bei einer anderen Aufgabe läuft ein Timer",
+    "timeNotePlaceholder": "Notiz (optional)"
   },
   "errors": {
     "recipientRequired": "Mindestens ein Empfänger ist erforderlich",

--- a/packages/client/src/i18n/locales/en.json
+++ b/packages/client/src/i18n/locales/en.json
@@ -87,7 +87,8 @@
     },
     "signOut": "Sign out",
     "noResults": "No results",
-    "navigation": "Navigation"
+    "navigation": "Navigation",
+    "add": "Add"
   },
   "auth": {
     "appName": "Atlas",
@@ -1138,7 +1139,15 @@
       "priority": "Priority",
       "dueDate": "Due date",
       "assignee": "Assignee"
-    }
+    },
+    "timeTracking": "Time tracking",
+    "startTimer": "Start timer",
+    "stopTimer": "Stop timer",
+    "logTime": "Log time",
+    "attachProjectToTrack": "Attach this task to a project to track time",
+    "selectProject": "Select a project…",
+    "timerRunningElsewhere": "A timer is running on another task",
+    "timeNotePlaceholder": "Note (optional)"
   },
   "errors": {
     "recipientRequired": "At least one recipient is required",

--- a/packages/client/src/i18n/locales/fr.json
+++ b/packages/client/src/i18n/locales/fr.json
@@ -87,7 +87,8 @@
     },
     "signOut": "Se déconnecter",
     "noResults": "Aucun résultat",
-    "navigation": "Navigation"
+    "navigation": "Navigation",
+    "add": "Ajouter"
   },
   "auth": {
     "appName": "Atlas",
@@ -1111,7 +1112,15 @@
       "priority": "Priorité",
       "dueDate": "Échéance",
       "assignee": "Responsable"
-    }
+    },
+    "timeTracking": "Suivi du temps",
+    "startTimer": "Démarrer le minuteur",
+    "stopTimer": "Arrêter le minuteur",
+    "logTime": "Saisir le temps",
+    "attachProjectToTrack": "Associez cette tâche à un projet pour suivre le temps",
+    "selectProject": "Sélectionner un projet…",
+    "timerRunningElsewhere": "Un minuteur est en cours sur une autre tâche",
+    "timeNotePlaceholder": "Note (facultatif)"
   },
   "errors": {
     "recipientRequired": "Au moins un destinataire est requis",

--- a/packages/client/src/i18n/locales/it.json
+++ b/packages/client/src/i18n/locales/it.json
@@ -87,7 +87,8 @@
     },
     "signOut": "Esci",
     "noResults": "Nessun risultato",
-    "navigation": "Navigazione"
+    "navigation": "Navigazione",
+    "add": "Aggiungi"
   },
   "auth": {
     "appName": "Atlas",
@@ -1111,7 +1112,15 @@
       "priority": "Priorità",
       "dueDate": "Scadenza",
       "assignee": "Assegnatario"
-    }
+    },
+    "timeTracking": "Tracciamento tempo",
+    "startTimer": "Avvia timer",
+    "stopTimer": "Ferma timer",
+    "logTime": "Registra tempo",
+    "attachProjectToTrack": "Collega questa attività a un progetto per tracciare il tempo",
+    "selectProject": "Seleziona un progetto…",
+    "timerRunningElsewhere": "Un timer è in esecuzione su un'altra attività",
+    "timeNotePlaceholder": "Nota (facoltativa)"
   },
   "errors": {
     "recipientRequired": "È necessario almeno un destinatario",

--- a/packages/client/src/i18n/locales/tr.json
+++ b/packages/client/src/i18n/locales/tr.json
@@ -87,7 +87,8 @@
     },
     "signOut": "Çıkış yap",
     "noResults": "Sonuç bulunamadı",
-    "navigation": "Gezinme"
+    "navigation": "Gezinme",
+    "add": "Ekle"
   },
   "auth": {
     "appName": "Atlas",
@@ -1111,7 +1112,15 @@
       "priority": "Öncelik",
       "dueDate": "Son tarih",
       "assignee": "Atanan"
-    }
+    },
+    "timeTracking": "Zaman takibi",
+    "startTimer": "Zamanlayıcıyı başlat",
+    "stopTimer": "Zamanlayıcıyı durdur",
+    "logTime": "Zaman gir",
+    "attachProjectToTrack": "Zaman takibi için bu görevi bir projeye bağlayın",
+    "selectProject": "Bir proje seçin…",
+    "timerRunningElsewhere": "Başka bir görevde zamanlayıcı çalışıyor",
+    "timeNotePlaceholder": "Not (isteğe bağlı)"
   },
   "errors": {
     "recipientRequired": "En az bir alıcı gereklidir",

--- a/packages/client/src/styles/tasks.css
+++ b/packages/client/src/styles/tasks.css
@@ -1000,6 +1000,26 @@
   cursor: grabbing;
 }
 
+/* Time-tracking toggle: hidden until row hover, but always shown while
+   the timer is running on this task. */
+.task-track-btn {
+  opacity: 0;
+  transition: opacity var(--transition-fast), background var(--transition-fast);
+}
+
+.task-item:hover .task-track-btn {
+  opacity: 0.6;
+}
+
+.task-track-btn:hover {
+  opacity: 1 !important;
+  background: var(--color-surface-hover) !important;
+}
+
+.task-track-btn.running {
+  opacity: 1 !important;
+}
+
 .task-item.dragging {
   opacity: 0.3;
   background: color-mix(in srgb, var(--color-text-primary) 3%, transparent);

--- a/packages/server/src/apps/work/controllers/task-time.controller.ts
+++ b/packages/server/src/apps/work/controllers/task-time.controller.ts
@@ -1,0 +1,154 @@
+import type { Request, Response } from 'express';
+import * as taskTime from '../services/task-time.service';
+import { canAccess } from '../../../services/app-permissions.service';
+import { logger } from '../../../utils/logger';
+
+// Maps service errors to HTTP status codes. The service throws plain
+// Errors with stable messages; everything else is a 500.
+function sendServiceError(res: Response, err: unknown, fallback: string) {
+  const msg = err instanceof Error ? err.message : fallback;
+  if (msg === 'No access to this project' || msg === 'Project not found') {
+    res.status(403).json({ success: false, error: msg });
+    return;
+  }
+  if (msg === 'Task not found') {
+    res.status(404).json({ success: false, error: msg });
+    return;
+  }
+  if (msg === 'Task must be attached to a project to track time') {
+    res.status(400).json({ success: false, error: msg });
+    return;
+  }
+  logger.error({ err }, fallback);
+  res.status(500).json({ success: false, error: fallback });
+}
+
+export async function listTaskTimeEntries(req: Request, res: Response) {
+  try {
+    const tenantId = req.auth!.tenantId!;
+    const taskId = req.params.id as string;
+    const [entries, totalMinutes] = await Promise.all([
+      taskTime.listByTask(req.auth!.userId, tenantId, taskId),
+      taskTime.getTaskTotalMinutes(tenantId, taskId),
+    ]);
+    res.json({ success: true, data: { entries, totalMinutes } });
+  } catch (error) {
+    logger.error({ error }, 'Failed to list task time entries');
+    res.status(500).json({ success: false, error: 'Failed to list task time entries' });
+  }
+}
+
+export async function createTaskTimeEntry(req: Request, res: Response) {
+  try {
+    const perm = req.workPerm!;
+    if (!canAccess(perm.role, 'create')) {
+      res.status(403).json({ success: false, error: 'No permission to create time entries' });
+      return;
+    }
+    const userId = req.auth!.userId;
+    const tenantId = req.auth!.tenantId!;
+    const taskId = req.params.id as string;
+    const { projectId, durationMinutes, workDate, startTime, endTime, notes, tags } = req.body;
+    const entry = await taskTime.logTime(userId, tenantId, {
+      taskId, projectId, durationMinutes: durationMinutes || 0, workDate, startTime, endTime, notes, tags,
+    }, { isAdmin: perm.role === 'admin' });
+    res.status(201).json({ success: true, data: entry });
+  } catch (error) {
+    sendServiceError(res, error, 'Failed to create task time entry');
+  }
+}
+
+export async function updateTaskTimeEntry(req: Request, res: Response) {
+  try {
+    const perm = req.workPerm!;
+    if (!canAccess(perm.role, 'update')) {
+      res.status(403).json({ success: false, error: 'No permission to update time entries' });
+      return;
+    }
+    const entryId = req.params.entryId as string;
+    const { durationMinutes, workDate, startTime, endTime, notes, tags } = req.body;
+    const updated = await taskTime.updateEntry(req.auth!.userId, req.auth!.tenantId!, entryId, {
+      durationMinutes, workDate, startTime, endTime, notes, tags,
+    });
+    if (!updated) {
+      res.status(404).json({ success: false, error: 'Time entry not found' });
+      return;
+    }
+    res.json({ success: true, data: updated });
+  } catch (error) {
+    logger.error({ error }, 'Failed to update task time entry');
+    res.status(500).json({ success: false, error: 'Failed to update task time entry' });
+  }
+}
+
+export async function deleteTaskTimeEntry(req: Request, res: Response) {
+  try {
+    const perm = req.workPerm!;
+    if (!canAccess(perm.role, 'delete') && !canAccess(perm.role, 'delete_own')) {
+      res.status(403).json({ success: false, error: 'No permission to delete time entries' });
+      return;
+    }
+    const ok = await taskTime.deleteEntry(req.auth!.userId, req.auth!.tenantId!, req.params.entryId as string);
+    if (!ok) {
+      res.status(404).json({ success: false, error: 'Time entry not found' });
+      return;
+    }
+    res.json({ success: true, data: null });
+  } catch (error) {
+    logger.error({ error }, 'Failed to delete task time entry');
+    res.status(500).json({ success: false, error: 'Failed to delete task time entry' });
+  }
+}
+
+// ─── Live timer ─────────────────────────────────────────────────────
+export async function getActiveTimer(req: Request, res: Response) {
+  try {
+    const timer = await taskTime.getActiveTimer(req.auth!.userId, req.auth!.tenantId!);
+    res.json({ success: true, data: timer });
+  } catch (error) {
+    logger.error({ error }, 'Failed to get active timer');
+    res.status(500).json({ success: false, error: 'Failed to get active timer' });
+  }
+}
+
+export async function startTaskTimer(req: Request, res: Response) {
+  try {
+    const perm = req.workPerm!;
+    if (!canAccess(perm.role, 'create')) {
+      res.status(403).json({ success: false, error: 'No permission to track time' });
+      return;
+    }
+    const taskId = req.params.id as string;
+    const { projectId, note } = req.body;
+    const timer = await taskTime.startTimer(
+      req.auth!.userId, req.auth!.tenantId!, taskId, projectId, note, { isAdmin: perm.role === 'admin' },
+    );
+    res.status(201).json({ success: true, data: timer });
+  } catch (error) {
+    sendServiceError(res, error, 'Failed to start timer');
+  }
+}
+
+export async function stopTaskTimer(req: Request, res: Response) {
+  try {
+    const entry = await taskTime.stopTimer(req.auth!.userId, req.auth!.tenantId!);
+    if (!entry) {
+      res.status(404).json({ success: false, error: 'No running timer' });
+      return;
+    }
+    res.json({ success: true, data: entry });
+  } catch (error) {
+    logger.error({ error }, 'Failed to stop timer');
+    res.status(500).json({ success: false, error: 'Failed to stop timer' });
+  }
+}
+
+export async function cancelTaskTimer(req: Request, res: Response) {
+  try {
+    const ok = await taskTime.cancelTimer(req.auth!.userId, req.auth!.tenantId!);
+    res.json({ success: true, data: { cancelled: ok } });
+  } catch (error) {
+    logger.error({ error }, 'Failed to cancel timer');
+    res.status(500).json({ success: false, error: 'Failed to cancel timer' });
+  }
+}

--- a/packages/server/src/apps/work/routes.ts
+++ b/packages/server/src/apps/work/routes.ts
@@ -5,6 +5,7 @@ import { withConcurrencyCheck } from '../../middleware/concurrency-check';
 import { tasks, projectProjects, projectTimeEntries, taskStatuses } from '../../db/schema';
 import * as controller from './controller';
 import * as taskStatusController from './controllers/task-statuses.controller';
+import * as taskTimeController from './controllers/task-time.controller';
 
 const router = Router();
 
@@ -62,6 +63,16 @@ router.delete('/tasks/:taskId/attachments/:attachmentId', controller.deleteAttac
 router.get('/tasks/:taskId/dependencies', controller.listDependencies);
 router.post('/tasks/:taskId/dependencies', controller.addDependency);
 router.delete('/tasks/:taskId/dependencies/:blockerTaskId', controller.removeDependency);
+
+// Task time tracking (per-task entries + live timer)
+router.get('/timer/active', taskTimeController.getActiveTimer);
+router.post('/timer/stop', taskTimeController.stopTaskTimer);
+router.post('/timer/cancel', taskTimeController.cancelTaskTimer);
+router.get('/tasks/:id/time-entries', taskTimeController.listTaskTimeEntries);
+router.post('/tasks/:id/time-entries', taskTimeController.createTaskTimeEntry);
+router.patch('/tasks/:id/time-entries/:entryId', taskTimeController.updateTaskTimeEntry);
+router.delete('/tasks/:id/time-entries/:entryId', taskTimeController.deleteTaskTimeEntry);
+router.post('/tasks/:id/timer/start', taskTimeController.startTaskTimer);
 
 // Task templates
 router.get('/templates', controller.listTemplates);

--- a/packages/server/src/apps/work/services/project-crud.service.ts
+++ b/packages/server/src/apps/work/services/project-crud.service.ts
@@ -1,6 +1,6 @@
 import { db } from '../../../config/database';
 import {
-  projectProjects, projectMembers, crmCompanies, users, accounts, projectTimeEntries, invoiceLineItems,
+  projectProjects, projectMembers, crmCompanies, users, accounts, projectTimeEntries, invoiceLineItems, taskTimeEntries,
 } from '../../../db/schema';
 import { eq, and, asc, sql } from 'drizzle-orm';
 import { logger } from '../../../utils/logger';
@@ -68,6 +68,17 @@ export async function listProjects(userId: string, tenantId: string, filters?: {
     .groupBy(projectTimeEntries.projectId)
     .as('time_agg');
 
+  // Task-tracked time rolls into the project total (read-layer only — it
+  // is not billable and never touches invoice_line_items).
+  const taskTimeAgg = db
+    .select({
+      projectId: taskTimeEntries.projectId,
+      taskTrackedMinutes: sql<number>`COALESCE(SUM(${taskTimeEntries.durationMinutes}), 0)`.as('task_tracked_minutes'),
+    })
+    .from(taskTimeEntries)
+    .groupBy(taskTimeEntries.projectId)
+    .as('task_time_agg');
+
   // Aggregate billed amounts from invoice line items once per project.
   const billingAgg = db
     .select({
@@ -99,7 +110,7 @@ export async function listProjects(userId: string, tenantId: string, filters?: {
       createdAt: projectProjects.createdAt,
       updatedAt: projectProjects.updatedAt,
       companyName: crmCompanies.name,
-      totalTrackedMinutes: sql<number>`COALESCE(${timeAgg.totalTrackedMinutes}, 0)`,
+      totalTrackedMinutes: sql<number>`COALESCE(${timeAgg.totalTrackedMinutes}, 0) + COALESCE(${taskTimeAgg.taskTrackedMinutes}, 0)`,
       totalBilledAmount: sql<number>`COALESCE(${billingAgg.totalBilledAmount}, 0)`,
       unbilledMinutes: sql<number>`COALESCE(${timeAgg.unbilledMinutes}, 0)`,
       billableMinutes: sql<number>`COALESCE(${timeAgg.billableMinutes}, 0)`,
@@ -108,6 +119,7 @@ export async function listProjects(userId: string, tenantId: string, filters?: {
     .from(projectProjects)
     .leftJoin(crmCompanies, eq(projectProjects.companyId, crmCompanies.id))
     .leftJoin(timeAgg, eq(timeAgg.projectId, projectProjects.id))
+    .leftJoin(taskTimeAgg, eq(taskTimeAgg.projectId, projectProjects.id))
     .leftJoin(billingAgg, eq(billingAgg.projectId, projectProjects.id))
     .where(and(...conditions))
     .orderBy(asc(projectProjects.sortOrder), asc(projectProjects.createdAt));
@@ -149,7 +161,7 @@ export async function getProject(userId: string, tenantId: string, id: string) {
       createdAt: projectProjects.createdAt,
       updatedAt: projectProjects.updatedAt,
       companyName: crmCompanies.name,
-      totalTrackedMinutes: sql<number>`COALESCE((SELECT SUM(duration_minutes) FROM project_time_entries WHERE project_id = ${projectProjects.id} AND is_archived = false), 0)`.as('total_tracked_minutes'),
+      totalTrackedMinutes: sql<number>`COALESCE((SELECT SUM(duration_minutes) FROM project_time_entries WHERE project_id = ${projectProjects.id} AND is_archived = false), 0) + COALESCE((SELECT SUM(duration_minutes) FROM task_time_entries WHERE project_id = ${projectProjects.id}), 0)`.as('total_tracked_minutes'),
       totalBilledAmount: sql<number>`COALESCE((SELECT SUM(ili.amount) FROM invoice_line_items ili INNER JOIN project_time_entries pte ON pte.id = ili.time_entry_id WHERE pte.project_id = ${projectProjects.id}), 0)`.as('total_billed_amount'),
     })
     .from(projectProjects)

--- a/packages/server/src/apps/work/services/project-crud.service.ts
+++ b/packages/server/src/apps/work/services/project-crud.service.ts
@@ -1,6 +1,6 @@
 import { db } from '../../../config/database';
 import {
-  projectProjects, projectMembers, crmCompanies, users, accounts, projectTimeEntries, invoiceLineItems, taskTimeEntries,
+  projectProjects, projectMembers, crmCompanies, users, accounts, projectTimeEntries, invoiceLineItems,
 } from '../../../db/schema';
 import { eq, and, asc, sql } from 'drizzle-orm';
 import { logger } from '../../../utils/logger';
@@ -68,17 +68,6 @@ export async function listProjects(userId: string, tenantId: string, filters?: {
     .groupBy(projectTimeEntries.projectId)
     .as('time_agg');
 
-  // Task-tracked time rolls into the project total (read-layer only — it
-  // is not billable and never touches invoice_line_items).
-  const taskTimeAgg = db
-    .select({
-      projectId: taskTimeEntries.projectId,
-      taskTrackedMinutes: sql<number>`COALESCE(SUM(${taskTimeEntries.durationMinutes}), 0)`.as('task_tracked_minutes'),
-    })
-    .from(taskTimeEntries)
-    .groupBy(taskTimeEntries.projectId)
-    .as('task_time_agg');
-
   // Aggregate billed amounts from invoice line items once per project.
   const billingAgg = db
     .select({
@@ -110,7 +99,7 @@ export async function listProjects(userId: string, tenantId: string, filters?: {
       createdAt: projectProjects.createdAt,
       updatedAt: projectProjects.updatedAt,
       companyName: crmCompanies.name,
-      totalTrackedMinutes: sql<number>`COALESCE(${timeAgg.totalTrackedMinutes}, 0) + COALESCE(${taskTimeAgg.taskTrackedMinutes}, 0)`,
+      totalTrackedMinutes: sql<number>`COALESCE(${timeAgg.totalTrackedMinutes}, 0)`,
       totalBilledAmount: sql<number>`COALESCE(${billingAgg.totalBilledAmount}, 0)`,
       unbilledMinutes: sql<number>`COALESCE(${timeAgg.unbilledMinutes}, 0)`,
       billableMinutes: sql<number>`COALESCE(${timeAgg.billableMinutes}, 0)`,
@@ -119,7 +108,6 @@ export async function listProjects(userId: string, tenantId: string, filters?: {
     .from(projectProjects)
     .leftJoin(crmCompanies, eq(projectProjects.companyId, crmCompanies.id))
     .leftJoin(timeAgg, eq(timeAgg.projectId, projectProjects.id))
-    .leftJoin(taskTimeAgg, eq(taskTimeAgg.projectId, projectProjects.id))
     .leftJoin(billingAgg, eq(billingAgg.projectId, projectProjects.id))
     .where(and(...conditions))
     .orderBy(asc(projectProjects.sortOrder), asc(projectProjects.createdAt));
@@ -161,7 +149,7 @@ export async function getProject(userId: string, tenantId: string, id: string) {
       createdAt: projectProjects.createdAt,
       updatedAt: projectProjects.updatedAt,
       companyName: crmCompanies.name,
-      totalTrackedMinutes: sql<number>`COALESCE((SELECT SUM(duration_minutes) FROM project_time_entries WHERE project_id = ${projectProjects.id} AND is_archived = false), 0) + COALESCE((SELECT SUM(duration_minutes) FROM task_time_entries WHERE project_id = ${projectProjects.id}), 0)`.as('total_tracked_minutes'),
+      totalTrackedMinutes: sql<number>`COALESCE((SELECT SUM(duration_minutes) FROM project_time_entries WHERE project_id = ${projectProjects.id} AND is_archived = false), 0)`.as('total_tracked_minutes'),
       totalBilledAmount: sql<number>`COALESCE((SELECT SUM(ili.amount) FROM invoice_line_items ili INNER JOIN project_time_entries pte ON pte.id = ili.time_entry_id WHERE pte.project_id = ${projectProjects.id}), 0)`.as('total_billed_amount'),
     })
     .from(projectProjects)

--- a/packages/server/src/apps/work/services/task-time.service.ts
+++ b/packages/server/src/apps/work/services/task-time.service.ts
@@ -1,6 +1,6 @@
 import { db } from '../../../config/database';
 import {
-  taskTimeEntries, activeTimers, tasks, projectProjects, projectMembers, userSettings,
+  projectTimeEntries, activeTimers, tasks, projectProjects, projectMembers, userSettings,
 } from '../../../db/schema';
 import { eq, and, desc, sql } from 'drizzle-orm';
 import { logger } from '../../../utils/logger';
@@ -23,7 +23,6 @@ async function resolveTimezone(userId: string): Promise<string> {
   const tz = settings?.timezone?.trim();
   if (!tz) return 'UTC';
   try {
-    // Throws RangeError for an invalid IANA zone.
     new Intl.DateTimeFormat('en-CA', { timeZone: tz });
     return tz;
   } catch {
@@ -32,15 +31,12 @@ async function resolveTimezone(userId: string): Promise<string> {
   }
 }
 
-// YYYY-MM-DD for `date` rendered in `timeZone`.
 function workDateIn(date: Date, timeZone: string): string {
-  // en-CA formats as YYYY-MM-DD.
   return new Intl.DateTimeFormat('en-CA', {
     timeZone, year: 'numeric', month: '2-digit', day: '2-digit',
   }).format(date);
 }
 
-// HH:MM (24h) for `date` rendered in `timeZone`.
 function clockTimeIn(date: Date, timeZone: string): string {
   return new Intl.DateTimeFormat('en-GB', {
     timeZone, hour: '2-digit', minute: '2-digit', hour12: false,
@@ -48,8 +44,6 @@ function clockTimeIn(date: Date, timeZone: string): string {
 }
 
 // ─── Access control ─────────────────────────────────────────────────
-// A task is trackable only when it belongs to a project the user can
-// reach. Mirrors the membership rule used by project time entries.
 async function assertProjectAccess(userId: string, tenantId: string, projectId: string, isAdmin?: boolean) {
   const [project] = await db
     .select({ id: projectProjects.id, ownerId: projectProjects.userId })
@@ -68,12 +62,12 @@ async function assertProjectAccess(userId: string, tenantId: string, projectId: 
 
 // Loads the task within the tenant and, when `projectId` is supplied for
 // a project-less task, attaches it (the inline-picker flow). Returns the
-// effective project id for the entry, or throws if none is resolvable.
+// effective project id and the task title (for the entry's description).
 async function resolveTaskProject(
   userId: string, tenantId: string, taskId: string, projectId?: string | null, isAdmin?: boolean,
-): Promise<string> {
+): Promise<{ projectId: string; title: string }> {
   const [task] = await db
-    .select({ id: tasks.id, projectId: tasks.projectId })
+    .select({ id: tasks.id, projectId: tasks.projectId, title: tasks.title })
     .from(tasks)
     .where(and(eq(tasks.id, taskId), eq(tasks.tenantId, tenantId)))
     .limit(1);
@@ -85,22 +79,30 @@ async function resolveTaskProject(
   }
   await assertProjectAccess(userId, tenantId, effectiveProjectId, isAdmin);
 
-  // Attach the project to the task if it had none (inline-picker flow).
   if (!task.projectId) {
     await db.update(tasks)
       .set({ projectId: effectiveProjectId, updatedAt: new Date() })
       .where(and(eq(tasks.id, taskId), eq(tasks.tenantId, tenantId)));
     logger.info({ taskId, projectId: effectiveProjectId }, 'Task attached to project for time tracking');
   }
-  return effectiveProjectId;
+  return { projectId: effectiveProjectId, title: task.title };
+}
+
+async function getTaskTitle(tenantId: string, taskId: string): Promise<string> {
+  const [task] = await db
+    .select({ title: tasks.title })
+    .from(tasks)
+    .where(and(eq(tasks.id, taskId), eq(tasks.tenantId, tenantId)))
+    .limit(1);
+  return task?.title || 'Task';
 }
 
 // ─── Input types ────────────────────────────────────────────────────
 interface LogTimeInput {
   taskId: string;
-  projectId?: string | null;   // required only when the task has no project yet
+  projectId?: string | null;
   durationMinutes: number;
-  workDate?: string | null;    // defaults to "today" in the user's timezone
+  workDate?: string | null;
   startTime?: string | null;
   endTime?: string | null;
   notes?: string | null;
@@ -109,45 +111,46 @@ interface LogTimeInput {
 
 // ─── Manual entry ───────────────────────────────────────────────────
 export async function logTime(userId: string, tenantId: string, input: LogTimeInput, options?: { isAdmin?: boolean }) {
-  const projectId = await resolveTaskProject(userId, tenantId, input.taskId, input.projectId, options?.isAdmin);
+  const { projectId, title } = await resolveTaskProject(userId, tenantId, input.taskId, input.projectId, options?.isAdmin);
   const tz = await resolveTimezone(userId);
   const now = new Date();
 
   const [created] = await db
-    .insert(taskTimeEntries)
+    .insert(projectTimeEntries)
     .values({
       tenantId,
       userId,
-      taskId: input.taskId,
       projectId,
+      taskId: input.taskId,
       durationMinutes: Math.max(0, Math.round(input.durationMinutes)),
       workDate: input.workDate ?? workDateIn(now, tz),
       startTime: input.startTime ?? null,
       endTime: input.endTime ?? null,
       notes: input.notes ?? null,
+      taskDescription: title.slice(0, 500),
       tags: input.tags ?? [],
       createdAt: now,
       updatedAt: now,
     })
     .returning();
 
-  logger.info({ userId, taskTimeEntryId: created.id }, 'Task time entry logged');
+  logger.info({ userId, timeEntryId: created.id, taskId: input.taskId }, 'Task time entry logged');
   return created;
 }
 
 export async function listByTask(userId: string, tenantId: string, taskId: string) {
   return db
     .select()
-    .from(taskTimeEntries)
-    .where(and(eq(taskTimeEntries.tenantId, tenantId), eq(taskTimeEntries.taskId, taskId)))
-    .orderBy(desc(taskTimeEntries.workDate), desc(taskTimeEntries.createdAt));
+    .from(projectTimeEntries)
+    .where(and(eq(projectTimeEntries.tenantId, tenantId), eq(projectTimeEntries.taskId, taskId)))
+    .orderBy(desc(projectTimeEntries.workDate), desc(projectTimeEntries.createdAt));
 }
 
 export async function getTaskTotalMinutes(tenantId: string, taskId: string): Promise<number> {
   const [row] = await db
-    .select({ total: sql<number>`COALESCE(SUM(${taskTimeEntries.durationMinutes}), 0)` })
-    .from(taskTimeEntries)
-    .where(and(eq(taskTimeEntries.tenantId, tenantId), eq(taskTimeEntries.taskId, taskId)));
+    .select({ total: sql<number>`COALESCE(SUM(${projectTimeEntries.durationMinutes}), 0)` })
+    .from(projectTimeEntries)
+    .where(and(eq(projectTimeEntries.tenantId, tenantId), eq(projectTimeEntries.taskId, taskId)));
   return Number(row?.total ?? 0);
 }
 
@@ -161,18 +164,18 @@ export async function updateEntry(userId: string, tenantId: string, id: string, 
   if (input.tags !== undefined) patch.tags = input.tags;
 
   const [updated] = await db
-    .update(taskTimeEntries)
+    .update(projectTimeEntries)
     .set(patch)
-    .where(and(eq(taskTimeEntries.id, id), eq(taskTimeEntries.tenantId, tenantId), eq(taskTimeEntries.userId, userId)))
+    .where(and(eq(projectTimeEntries.id, id), eq(projectTimeEntries.tenantId, tenantId), eq(projectTimeEntries.userId, userId)))
     .returning();
   return updated ?? null;
 }
 
 export async function deleteEntry(userId: string, tenantId: string, id: string): Promise<boolean> {
   const deleted = await db
-    .delete(taskTimeEntries)
-    .where(and(eq(taskTimeEntries.id, id), eq(taskTimeEntries.tenantId, tenantId), eq(taskTimeEntries.userId, userId)))
-    .returning({ id: taskTimeEntries.id });
+    .delete(projectTimeEntries)
+    .where(and(eq(projectTimeEntries.id, id), eq(projectTimeEntries.tenantId, tenantId), eq(projectTimeEntries.userId, userId)))
+    .returning({ id: projectTimeEntries.id });
   return deleted.length > 0;
 }
 
@@ -195,7 +198,7 @@ export async function startTimer(
   if (existing) {
     await stopTimer(userId, tenantId, options);
   }
-  const effectiveProjectId = await resolveTaskProject(userId, tenantId, taskId, projectId, options?.isAdmin);
+  const { projectId: effectiveProjectId } = await resolveTaskProject(userId, tenantId, taskId, projectId, options?.isAdmin);
   const now = new Date();
   const [timer] = await db
     .insert(activeTimers)
@@ -205,30 +208,32 @@ export async function startTimer(
   return timer;
 }
 
-// Stops the running timer, converting elapsed time into a task time
-// entry stamped in the user's timezone. Returns the created entry, or
-// null when no timer was running.
-export async function stopTimer(userId: string, tenantId: string, options?: { isAdmin?: boolean }) {
+// Stops the running timer, converting elapsed time into a project time
+// entry (linked to the task) stamped in the user's timezone. Returns the
+// created entry, or null when no timer was running.
+export async function stopTimer(userId: string, tenantId: string, _options?: { isAdmin?: boolean }) {
   const timer = await getActiveTimer(userId, tenantId);
   if (!timer) return null;
 
   const tz = await resolveTimezone(userId);
+  const title = await getTaskTitle(tenantId, timer.taskId);
   const startedAt = new Date(timer.startedAt);
   const endedAt = new Date();
   const durationMinutes = Math.max(1, Math.round((endedAt.getTime() - startedAt.getTime()) / 60000));
 
   const [created] = await db
-    .insert(taskTimeEntries)
+    .insert(projectTimeEntries)
     .values({
       tenantId,
       userId,
-      taskId: timer.taskId,
       projectId: timer.projectId,
+      taskId: timer.taskId,
       durationMinutes,
       workDate: workDateIn(startedAt, tz),
       startTime: clockTimeIn(startedAt, tz),
       endTime: clockTimeIn(endedAt, tz),
       notes: timer.note ?? null,
+      taskDescription: title.slice(0, 500),
       tags: [],
       createdAt: endedAt,
       updatedAt: endedAt,
@@ -236,7 +241,7 @@ export async function stopTimer(userId: string, tenantId: string, options?: { is
     .returning();
 
   await db.delete(activeTimers).where(eq(activeTimers.id, timer.id));
-  logger.info({ userId, taskTimeEntryId: created.id, durationMinutes }, 'Task timer stopped');
+  logger.info({ userId, timeEntryId: created.id, durationMinutes }, 'Task timer stopped');
   return created;
 }
 

--- a/packages/server/src/apps/work/services/task-time.service.ts
+++ b/packages/server/src/apps/work/services/task-time.service.ts
@@ -1,0 +1,250 @@
+import { db } from '../../../config/database';
+import {
+  taskTimeEntries, activeTimers, tasks, projectProjects, projectMembers, userSettings,
+} from '../../../db/schema';
+import { eq, and, desc, sql } from 'drizzle-orm';
+import { logger } from '../../../utils/logger';
+import { getAccountIdForUser } from '../../../utils/account-lookup';
+
+// ─── Timezone helpers ───────────────────────────────────────────────
+// Time entries store a local work_date (YYYY-MM-DD) and HH:MM clock
+// times. Those must reflect the user's configured timezone, not the
+// server's UTC clock — otherwise a timer stopped at 00:30 local lands on
+// the wrong calendar day. We resolve the timezone from user_settings and
+// derive the parts with Intl, falling back to UTC when unset/invalid.
+async function resolveTimezone(userId: string): Promise<string> {
+  const accountId = await getAccountIdForUser(userId);
+  if (!accountId) return 'UTC';
+  const [settings] = await db
+    .select({ timezone: userSettings.timezone })
+    .from(userSettings)
+    .where(eq(userSettings.accountId, accountId))
+    .limit(1);
+  const tz = settings?.timezone?.trim();
+  if (!tz) return 'UTC';
+  try {
+    // Throws RangeError for an invalid IANA zone.
+    new Intl.DateTimeFormat('en-CA', { timeZone: tz });
+    return tz;
+  } catch {
+    logger.warn({ userId, tz }, 'Invalid user timezone, falling back to UTC');
+    return 'UTC';
+  }
+}
+
+// YYYY-MM-DD for `date` rendered in `timeZone`.
+function workDateIn(date: Date, timeZone: string): string {
+  // en-CA formats as YYYY-MM-DD.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone, year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(date);
+}
+
+// HH:MM (24h) for `date` rendered in `timeZone`.
+function clockTimeIn(date: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone, hour: '2-digit', minute: '2-digit', hour12: false,
+  }).format(date);
+}
+
+// ─── Access control ─────────────────────────────────────────────────
+// A task is trackable only when it belongs to a project the user can
+// reach. Mirrors the membership rule used by project time entries.
+async function assertProjectAccess(userId: string, tenantId: string, projectId: string, isAdmin?: boolean) {
+  const [project] = await db
+    .select({ id: projectProjects.id, ownerId: projectProjects.userId })
+    .from(projectProjects)
+    .where(and(eq(projectProjects.id, projectId), eq(projectProjects.tenantId, tenantId)))
+    .limit(1);
+  if (!project) throw new Error('Project not found');
+  if (isAdmin || project.ownerId === userId) return;
+  const [member] = await db
+    .select({ id: projectMembers.id })
+    .from(projectMembers)
+    .where(and(eq(projectMembers.projectId, projectId), eq(projectMembers.userId, userId)))
+    .limit(1);
+  if (!member) throw new Error('No access to this project');
+}
+
+// Loads the task within the tenant and, when `projectId` is supplied for
+// a project-less task, attaches it (the inline-picker flow). Returns the
+// effective project id for the entry, or throws if none is resolvable.
+async function resolveTaskProject(
+  userId: string, tenantId: string, taskId: string, projectId?: string | null, isAdmin?: boolean,
+): Promise<string> {
+  const [task] = await db
+    .select({ id: tasks.id, projectId: tasks.projectId })
+    .from(tasks)
+    .where(and(eq(tasks.id, taskId), eq(tasks.tenantId, tenantId)))
+    .limit(1);
+  if (!task) throw new Error('Task not found');
+
+  const effectiveProjectId = task.projectId ?? projectId ?? null;
+  if (!effectiveProjectId) {
+    throw new Error('Task must be attached to a project to track time');
+  }
+  await assertProjectAccess(userId, tenantId, effectiveProjectId, isAdmin);
+
+  // Attach the project to the task if it had none (inline-picker flow).
+  if (!task.projectId) {
+    await db.update(tasks)
+      .set({ projectId: effectiveProjectId, updatedAt: new Date() })
+      .where(and(eq(tasks.id, taskId), eq(tasks.tenantId, tenantId)));
+    logger.info({ taskId, projectId: effectiveProjectId }, 'Task attached to project for time tracking');
+  }
+  return effectiveProjectId;
+}
+
+// ─── Input types ────────────────────────────────────────────────────
+interface LogTimeInput {
+  taskId: string;
+  projectId?: string | null;   // required only when the task has no project yet
+  durationMinutes: number;
+  workDate?: string | null;    // defaults to "today" in the user's timezone
+  startTime?: string | null;
+  endTime?: string | null;
+  notes?: string | null;
+  tags?: string[];
+}
+
+// ─── Manual entry ───────────────────────────────────────────────────
+export async function logTime(userId: string, tenantId: string, input: LogTimeInput, options?: { isAdmin?: boolean }) {
+  const projectId = await resolveTaskProject(userId, tenantId, input.taskId, input.projectId, options?.isAdmin);
+  const tz = await resolveTimezone(userId);
+  const now = new Date();
+
+  const [created] = await db
+    .insert(taskTimeEntries)
+    .values({
+      tenantId,
+      userId,
+      taskId: input.taskId,
+      projectId,
+      durationMinutes: Math.max(0, Math.round(input.durationMinutes)),
+      workDate: input.workDate ?? workDateIn(now, tz),
+      startTime: input.startTime ?? null,
+      endTime: input.endTime ?? null,
+      notes: input.notes ?? null,
+      tags: input.tags ?? [],
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+
+  logger.info({ userId, taskTimeEntryId: created.id }, 'Task time entry logged');
+  return created;
+}
+
+export async function listByTask(userId: string, tenantId: string, taskId: string) {
+  return db
+    .select()
+    .from(taskTimeEntries)
+    .where(and(eq(taskTimeEntries.tenantId, tenantId), eq(taskTimeEntries.taskId, taskId)))
+    .orderBy(desc(taskTimeEntries.workDate), desc(taskTimeEntries.createdAt));
+}
+
+export async function getTaskTotalMinutes(tenantId: string, taskId: string): Promise<number> {
+  const [row] = await db
+    .select({ total: sql<number>`COALESCE(SUM(${taskTimeEntries.durationMinutes}), 0)` })
+    .from(taskTimeEntries)
+    .where(and(eq(taskTimeEntries.tenantId, tenantId), eq(taskTimeEntries.taskId, taskId)));
+  return Number(row?.total ?? 0);
+}
+
+export async function updateEntry(userId: string, tenantId: string, id: string, input: Partial<LogTimeInput>) {
+  const patch: Record<string, unknown> = { updatedAt: new Date() };
+  if (input.durationMinutes !== undefined) patch.durationMinutes = Math.max(0, Math.round(input.durationMinutes));
+  if (input.workDate !== undefined) patch.workDate = input.workDate;
+  if (input.startTime !== undefined) patch.startTime = input.startTime;
+  if (input.endTime !== undefined) patch.endTime = input.endTime;
+  if (input.notes !== undefined) patch.notes = input.notes;
+  if (input.tags !== undefined) patch.tags = input.tags;
+
+  const [updated] = await db
+    .update(taskTimeEntries)
+    .set(patch)
+    .where(and(eq(taskTimeEntries.id, id), eq(taskTimeEntries.tenantId, tenantId), eq(taskTimeEntries.userId, userId)))
+    .returning();
+  return updated ?? null;
+}
+
+export async function deleteEntry(userId: string, tenantId: string, id: string): Promise<boolean> {
+  const deleted = await db
+    .delete(taskTimeEntries)
+    .where(and(eq(taskTimeEntries.id, id), eq(taskTimeEntries.tenantId, tenantId), eq(taskTimeEntries.userId, userId)))
+    .returning({ id: taskTimeEntries.id });
+  return deleted.length > 0;
+}
+
+// ─── Live timer ─────────────────────────────────────────────────────
+export async function getActiveTimer(userId: string, tenantId: string) {
+  const [timer] = await db
+    .select()
+    .from(activeTimers)
+    .where(and(eq(activeTimers.tenantId, tenantId), eq(activeTimers.userId, userId)))
+    .limit(1);
+  return timer ?? null;
+}
+
+// Starts a timer for a task. One per user — starting a new one while
+// another runs auto-stops the previous (writes its entry first).
+export async function startTimer(
+  userId: string, tenantId: string, taskId: string, projectId?: string | null, note?: string | null, options?: { isAdmin?: boolean },
+) {
+  const existing = await getActiveTimer(userId, tenantId);
+  if (existing) {
+    await stopTimer(userId, tenantId, options);
+  }
+  const effectiveProjectId = await resolveTaskProject(userId, tenantId, taskId, projectId, options?.isAdmin);
+  const now = new Date();
+  const [timer] = await db
+    .insert(activeTimers)
+    .values({ tenantId, userId, taskId, projectId: effectiveProjectId, startedAt: now, note: note ?? null, createdAt: now })
+    .returning();
+  logger.info({ userId, taskId, timerId: timer.id }, 'Task timer started');
+  return timer;
+}
+
+// Stops the running timer, converting elapsed time into a task time
+// entry stamped in the user's timezone. Returns the created entry, or
+// null when no timer was running.
+export async function stopTimer(userId: string, tenantId: string, options?: { isAdmin?: boolean }) {
+  const timer = await getActiveTimer(userId, tenantId);
+  if (!timer) return null;
+
+  const tz = await resolveTimezone(userId);
+  const startedAt = new Date(timer.startedAt);
+  const endedAt = new Date();
+  const durationMinutes = Math.max(1, Math.round((endedAt.getTime() - startedAt.getTime()) / 60000));
+
+  const [created] = await db
+    .insert(taskTimeEntries)
+    .values({
+      tenantId,
+      userId,
+      taskId: timer.taskId,
+      projectId: timer.projectId,
+      durationMinutes,
+      workDate: workDateIn(startedAt, tz),
+      startTime: clockTimeIn(startedAt, tz),
+      endTime: clockTimeIn(endedAt, tz),
+      notes: timer.note ?? null,
+      tags: [],
+      createdAt: endedAt,
+      updatedAt: endedAt,
+    })
+    .returning();
+
+  await db.delete(activeTimers).where(eq(activeTimers.id, timer.id));
+  logger.info({ userId, taskTimeEntryId: created.id, durationMinutes }, 'Task timer stopped');
+  return created;
+}
+
+// Discards a running timer without recording an entry.
+export async function cancelTimer(userId: string, tenantId: string): Promise<boolean> {
+  const deleted = await db
+    .delete(activeTimers)
+    .where(and(eq(activeTimers.tenantId, tenantId), eq(activeTimers.userId, userId)))
+    .returning({ id: activeTimers.id });
+  return deleted.length > 0;
+}

--- a/packages/server/src/db/bootstrap.ts
+++ b/packages/server/src/db/bootstrap.ts
@@ -71,6 +71,18 @@ export async function bootstrapDatabase() {
             skipped += 1;
           } else if (code === '42P01' && /ALTER TABLE/i.test(stmt)) {
             skipped += 1;
+          } else if (
+            /ALTER TABLE/i.test(stmt) && /ADD CONSTRAINT/i.test(stmt) &&
+            (code === '23503' || code === '42710')
+          ) {
+            // Re-adding a baseline FK constraint that no longer fits the
+            // migrated data (23503 fk_violation, e.g. the legacy
+            // tasks → task_projects FK after the work-merge) or that already
+            // exists (42710 duplicate_object). Both are benign on replay:
+            // later legacy-data steps repoint constraints to their current
+            // target. Without this guard the snapshot replay bricks every
+            // restart of an already-migrated DB.
+            skipped += 1;
           } else {
             logger.error({ err, file, stmt: stmt.slice(0, 200) }, 'Migration statement failed');
             throw err;

--- a/packages/server/src/db/bootstrap.ts
+++ b/packages/server/src/db/bootstrap.ts
@@ -6,6 +6,7 @@ import { migrateWorkMerge } from './migrations/2026-04-15-work-merge';
 import { migrateCrmWorkflowSteps } from './migrations/2026-04-22-crm-workflow-steps';
 import { migrateMessageChannels } from './migrations/2026-04-28-message-channels';
 import { migrateGmailMessagePartialIndex } from './migrations/2026-04-29-gmail-message-partial-index';
+import { migrateTaskTimeTracking } from './migrations/2026-05-20-task-time-tracking';
 import { db } from '../config/database';
 import { tenants } from './schema';
 import { seedBlocklistForTenants } from '../apps/crm/services/blocklist-seed.service';
@@ -475,6 +476,13 @@ async function migrateLegacyData() {
     await migrateGmailMessagePartialIndex();
   } catch (err) {
     logger.error({ err }, 'gmail-message-partial-index migration failed');
+  }
+
+  // Task time tracking tables (task_time_entries + active_timers) — idempotent.
+  try {
+    await migrateTaskTimeTracking();
+  } catch (err) {
+    logger.error({ err }, 'task-time-tracking migration failed');
   }
 
   // Drop the 5 dead user_settings.tables_* columns left over from the

--- a/packages/server/src/db/migrations/2026-05-20-task-time-tracking.ts
+++ b/packages/server/src/db/migrations/2026-05-20-task-time-tracking.ts
@@ -1,30 +1,14 @@
 import { pool } from '../../config/database';
 import { logger } from '../../utils/logger';
 
-// Task-level time tracking. Time is logged against a task and always
-// rolls up to a project (project_id NOT NULL), so it feeds the project's
-// overall time totals. active_timers holds one running timer per user;
-// stopping it writes a task_time_entries row. Idempotent.
-const CREATE_TASK_TIME_ENTRIES = `
-  CREATE TABLE IF NOT EXISTS task_time_entries (
-    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    tenant_id uuid NOT NULL REFERENCES tenants(id),
-    user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    task_id uuid NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
-    project_id uuid NOT NULL REFERENCES project_projects(id) ON DELETE CASCADE,
-    duration_minutes integer NOT NULL DEFAULT 0,
-    work_date varchar(10) NOT NULL,
-    start_time varchar(5),
-    end_time varchar(5),
-    notes text,
-    tags jsonb NOT NULL DEFAULT '[]'::jsonb,
-    created_at timestamptz NOT NULL DEFAULT now(),
-    updated_at timestamptz NOT NULL DEFAULT now()
-  );
-  CREATE INDEX IF NOT EXISTS idx_task_time_entries_tenant ON task_time_entries (tenant_id);
-  CREATE INDEX IF NOT EXISTS idx_task_time_entries_task ON task_time_entries (task_id);
-  CREATE INDEX IF NOT EXISTS idx_task_time_entries_project ON task_time_entries (project_id);
-  CREATE INDEX IF NOT EXISTS idx_task_time_entries_user_date ON task_time_entries (user_id, work_date);
+// Task time tracking. Task time is stored directly in project_time_entries
+// (linked via task_id) so it rolls into project totals, the time tab,
+// dashboards, reports, and billing automatically. active_timers holds one
+// running timer per user; stopping it writes a project_time_entries row.
+// Idempotent — safe to replay on every boot.
+const ADD_TASK_ID = `
+  ALTER TABLE project_time_entries ADD COLUMN IF NOT EXISTS task_id uuid REFERENCES tasks(id) ON DELETE SET NULL;
+  CREATE INDEX IF NOT EXISTS idx_project_time_entries_task ON project_time_entries (task_id);
 `;
 
 const CREATE_ACTIVE_TIMERS = `
@@ -42,11 +26,31 @@ const CREATE_ACTIVE_TIMERS = `
   CREATE INDEX IF NOT EXISTS idx_active_timers_task ON active_timers (task_id);
 `;
 
+// One-time: an earlier build stored task time in a dedicated
+// task_time_entries table. Fold any such rows into project_time_entries
+// and drop the table. The IF EXISTS guard makes this a no-op once done.
+const MIGRATE_AND_DROP_LEGACY = `
+  INSERT INTO project_time_entries
+    (id, tenant_id, user_id, project_id, task_id, duration_minutes, work_date,
+     start_time, end_time, notes, tags, billable, created_at, updated_at)
+  SELECT id, tenant_id, user_id, project_id, task_id, duration_minutes, work_date,
+     start_time, end_time, notes, tags, true, created_at, updated_at
+  FROM task_time_entries
+  ON CONFLICT (id) DO NOTHING;
+  DROP TABLE task_time_entries;
+`;
+
 export async function migrateTaskTimeTracking(): Promise<void> {
   const c = await pool.connect();
   try {
-    await c.query(CREATE_TASK_TIME_ENTRIES);
+    await c.query(ADD_TASK_ID);
     await c.query(CREATE_ACTIVE_TIMERS);
+    // Replay-safe: only runs while the legacy table still exists.
+    const exists = await c.query(`SELECT to_regclass('public.task_time_entries') AS t`);
+    if (exists.rows[0]?.t) {
+      await c.query(MIGRATE_AND_DROP_LEGACY);
+      logger.info('task-time-tracking: migrated legacy task_time_entries into project_time_entries');
+    }
     logger.debug('task-time-tracking migration applied');
   } finally {
     c.release();

--- a/packages/server/src/db/migrations/2026-05-20-task-time-tracking.ts
+++ b/packages/server/src/db/migrations/2026-05-20-task-time-tracking.ts
@@ -1,0 +1,54 @@
+import { pool } from '../../config/database';
+import { logger } from '../../utils/logger';
+
+// Task-level time tracking. Time is logged against a task and always
+// rolls up to a project (project_id NOT NULL), so it feeds the project's
+// overall time totals. active_timers holds one running timer per user;
+// stopping it writes a task_time_entries row. Idempotent.
+const CREATE_TASK_TIME_ENTRIES = `
+  CREATE TABLE IF NOT EXISTS task_time_entries (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id uuid NOT NULL REFERENCES tenants(id),
+    user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    task_id uuid NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    project_id uuid NOT NULL REFERENCES project_projects(id) ON DELETE CASCADE,
+    duration_minutes integer NOT NULL DEFAULT 0,
+    work_date varchar(10) NOT NULL,
+    start_time varchar(5),
+    end_time varchar(5),
+    notes text,
+    tags jsonb NOT NULL DEFAULT '[]'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+  );
+  CREATE INDEX IF NOT EXISTS idx_task_time_entries_tenant ON task_time_entries (tenant_id);
+  CREATE INDEX IF NOT EXISTS idx_task_time_entries_task ON task_time_entries (task_id);
+  CREATE INDEX IF NOT EXISTS idx_task_time_entries_project ON task_time_entries (project_id);
+  CREATE INDEX IF NOT EXISTS idx_task_time_entries_user_date ON task_time_entries (user_id, work_date);
+`;
+
+const CREATE_ACTIVE_TIMERS = `
+  CREATE TABLE IF NOT EXISTS active_timers (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id uuid NOT NULL REFERENCES tenants(id),
+    user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    task_id uuid NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    project_id uuid NOT NULL REFERENCES project_projects(id) ON DELETE CASCADE,
+    started_at timestamptz NOT NULL DEFAULT now(),
+    note text,
+    created_at timestamptz NOT NULL DEFAULT now()
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_active_timers_user_unique ON active_timers (tenant_id, user_id);
+  CREATE INDEX IF NOT EXISTS idx_active_timers_task ON active_timers (task_id);
+`;
+
+export async function migrateTaskTimeTracking(): Promise<void> {
+  const c = await pool.connect();
+  try {
+    await c.query(CREATE_TASK_TIME_ENTRIES);
+    await c.query(CREATE_ACTIVE_TIMERS);
+    logger.debug('task-time-tracking migration applied');
+  } finally {
+    c.release();
+  }
+}

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1789,6 +1789,49 @@ export const projectTimeEntries = pgTable('project_time_entries', {
   billedIdx: index('idx_project_time_entries_billed').on(table.billed, table.billable),
 }));
 
+// ─── Work: Task time tracking ───────────────────────────────────────
+// Time logged against a specific task. Tracking always requires a
+// project, so project_id is NOT NULL — these entries roll up into the
+// project's overall time totals (read-layer aggregation in
+// project-time.service). work_date / start_time / end_time are stamped
+// in the user's configured timezone (user_settings.timezone), not UTC.
+export const taskTimeEntries = pgTable('task_time_entries', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  tenantId: uuid('tenant_id').notNull().references(() => tenants.id),
+  userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  taskId: uuid('task_id').notNull().references(() => tasks.id, { onDelete: 'cascade' }),
+  projectId: uuid('project_id').notNull().references(() => projectProjects.id, { onDelete: 'cascade' }),
+  durationMinutes: integer('duration_minutes').notNull().default(0),
+  workDate: varchar('work_date', { length: 10 }).notNull(),
+  startTime: varchar('start_time', { length: 5 }),
+  endTime: varchar('end_time', { length: 5 }),
+  notes: text('notes'),
+  tags: jsonb('tags').$type<string[]>().notNull().default([]),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  tenantIdx: index('idx_task_time_entries_tenant').on(table.tenantId),
+  taskIdx: index('idx_task_time_entries_task').on(table.taskId),
+  projectIdx: index('idx_task_time_entries_project').on(table.projectId),
+  userDateIdx: index('idx_task_time_entries_user_date').on(table.userId, table.workDate),
+}));
+
+// One running timer per user. On stop, the elapsed time is written as a
+// task_time_entries row and the active timer is deleted.
+export const activeTimers = pgTable('active_timers', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  tenantId: uuid('tenant_id').notNull().references(() => tenants.id),
+  userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  taskId: uuid('task_id').notNull().references(() => tasks.id, { onDelete: 'cascade' }),
+  projectId: uuid('project_id').notNull().references(() => projectProjects.id, { onDelete: 'cascade' }),
+  startedAt: timestamp('started_at', { withTimezone: true }).defaultNow().notNull(),
+  note: text('note'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  userUnique: uniqueIndex('idx_active_timers_user_unique').on(table.tenantId, table.userId),
+  taskIdx: index('idx_active_timers_task').on(table.taskId),
+}));
+
 // ─── Projects: Settings ───────────────────────────────────────────
 export const projectSettings = pgTable('project_settings', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1765,6 +1765,10 @@ export const projectTimeEntries = pgTable('project_time_entries', {
   tenantId: uuid('tenant_id').notNull().references(() => tenants.id),
   userId: uuid('user_id').notNull(),
   projectId: uuid('project_id').notNull().references(() => projectProjects.id, { onDelete: 'cascade' }),
+  // Optional link to the task this time was tracked against. Task time
+  // tracking writes into this table (not a separate one) so it flows into
+  // project totals, the time tab, dashboards, reports, and billing for free.
+  taskId: uuid('task_id').references(() => tasks.id, { onDelete: 'set null' }),
   durationMinutes: integer('duration_minutes').notNull().default(0),
   workDate: varchar('work_date', { length: 10 }).notNull(),
   startTime: varchar('start_time', { length: 5 }),
@@ -1787,37 +1791,12 @@ export const projectTimeEntries = pgTable('project_time_entries', {
   projectIdx: index('idx_project_time_entries_project').on(table.projectId),
   userDateIdx: index('idx_project_time_entries_user_date').on(table.userId, table.workDate),
   billedIdx: index('idx_project_time_entries_billed').on(table.billed, table.billable),
+  taskIdx: index('idx_project_time_entries_task').on(table.taskId),
 }));
 
 // ─── Work: Task time tracking ───────────────────────────────────────
-// Time logged against a specific task. Tracking always requires a
-// project, so project_id is NOT NULL — these entries roll up into the
-// project's overall time totals (read-layer aggregation in
-// project-time.service). work_date / start_time / end_time are stamped
-// in the user's configured timezone (user_settings.timezone), not UTC.
-export const taskTimeEntries = pgTable('task_time_entries', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  tenantId: uuid('tenant_id').notNull().references(() => tenants.id),
-  userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-  taskId: uuid('task_id').notNull().references(() => tasks.id, { onDelete: 'cascade' }),
-  projectId: uuid('project_id').notNull().references(() => projectProjects.id, { onDelete: 'cascade' }),
-  durationMinutes: integer('duration_minutes').notNull().default(0),
-  workDate: varchar('work_date', { length: 10 }).notNull(),
-  startTime: varchar('start_time', { length: 5 }),
-  endTime: varchar('end_time', { length: 5 }),
-  notes: text('notes'),
-  tags: jsonb('tags').$type<string[]>().notNull().default([]),
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
-}, (table) => ({
-  tenantIdx: index('idx_task_time_entries_tenant').on(table.tenantId),
-  taskIdx: index('idx_task_time_entries_task').on(table.taskId),
-  projectIdx: index('idx_task_time_entries_project').on(table.projectId),
-  userDateIdx: index('idx_task_time_entries_user_date').on(table.userId, table.workDate),
-}));
-
 // One running timer per user. On stop, the elapsed time is written as a
-// task_time_entries row and the active timer is deleted.
+// project_time_entries row (with task_id set) and the timer is deleted.
 export const activeTimers = pgTable('active_timers', {
   id: uuid('id').primaryKey().defaultRandom(),
   tenantId: uuid('tenant_id').notNull().references(() => tenants.id),


### PR DESCRIPTION
## Summary

Adds time tracking on individual tasks. Time is tracked against a task, attributed to its project, and flows into all existing project time surfaces (totals, time tab, dashboard, recent activity, reports, billing) automatically.

### Features
- **Live start/stop timer** and **manual time log** on each task — a start/stop button on every task row plus a full time section in the task detail.
- **Tracking requires a project.** A project-less task is attached to a project via an inline picker the moment you start tracking.
- **Timezone-aware:** `work_date` / `start_time` / `end_time` are stamped from the user's configured `user_settings.timezone` (Intl, UTC fallback) instead of server UTC.
- **i18n** for all new strings across en/de/fr/it/tr.

### Data model
- Task time is stored in `project_time_entries` with a new nullable `task_id` FK (`ON DELETE SET NULL`) + index — so it natively rolls into project totals, the time tab, `/work` recent activity, reports, and billing. No parallel aggregation needed.
- A new `active_timers` table holds one running timer per user; stopping it writes a `project_time_entries` row labelled with the task title.
- REST: `GET/POST /work/tasks/:id/time-entries`, `PATCH/DELETE …/:entryId`, `POST /work/tasks/:id/timer/start`, `POST /work/timer/stop|cancel`, `GET /work/timer/active`.

### Bootstrap hardening (independent fix)
The snapshot replay in `bootstrapDatabase` re-adds the baseline `tasks → task_projects` FK on every start. On an already-migrated DB (post work-merge, `task_projects` emptied) that throws `23503` and bricks boot before the legacy-data repoint runs — so any restart of a long-running instance fails. This swallows the benign `23503`/`42710` errors specifically for `ALTER TABLE … ADD CONSTRAINT` replays (the repoint step fixes the FK afterward).

## Migration
Idempotent and replay-safe: adds `task_id` to `project_time_entries`, creates `active_timers`, and folds any rows from an earlier `task_time_entries` table into `project_time_entries` before dropping it.

## Testing
- `tsc --noEmit` passes for both `packages/server` and `packages/client`.
- Built and deployed to a live self-hosted instance; verified health, migration, and that tracked task time appears in project totals and the recent-activity feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added task time tracking with a live timer button on task items
  * Manual time logging with hours, minutes, and optional notes
  * Display of total tracked time per task
  * Project selection for time tracking
  * Time entry management with edit and delete options
  * Multilingual support for time tracking UI (English, German, French, Italian, Turkish)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gorkem-bwl/atlas/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->